### PR TITLE
Add listGitRepo tool

### DIFF
--- a/pkg/toolsets/fleet/list_gitrepos.go
+++ b/pkg/toolsets/fleet/list_gitrepos.go
@@ -1,0 +1,45 @@
+package fleet
+
+import (
+	"context"
+
+	"mcp/pkg/client"
+	"mcp/pkg/response"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+)
+
+// listGitRepoParams specifies the parameters needed to list Fleet GitRepo resources.
+type listGitRepoParams struct {
+	Workspace string `json:"workspace" jsonschema:"the workspace of the gitrepo"`
+}
+
+// listGitRepos retrieves all Fleet GitRepo resources for a specific workspace.
+// The function queries the 'local' cluster where Fleet runs and returns all GitRepos
+// in the specified workspace namespace, along with UI context for building resource links.
+func (t *Tools) listGitRepos(ctx context.Context, toolReq *mcp.CallToolRequest, params listGitRepoParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("listGitRepos called")
+
+	gitRepos, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster:   "local",
+		Kind:      "gitrepo",
+		Namespace: params.Workspace,
+		URL:       toolReq.Extra.Header.Get(urlHeader),
+		Token:     toolReq.Extra.Header.Get(tokenHeader),
+	})
+	if err != nil {
+		zap.L().Error("failed to list gitrepos", zap.String("tool", "listGitRepos"), zap.Error(err))
+		return nil, nil, err
+	}
+
+	mcpResponse, err := response.CreateMcpResponse(gitRepos, "local")
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zap.String("tool", "listGitRepos"), zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/fleet/list_gitrepos_test.go
+++ b/pkg/toolsets/fleet/list_gitrepos_test.go
@@ -1,0 +1,180 @@
+package fleet
+
+import (
+	"context"
+	"testing"
+
+	"mcp/pkg/client"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+var fakeGitRepo1 = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "fleet.cattle.io/v1alpha1",
+		"kind":       "GitRepo",
+		"metadata": map[string]any{
+			"name":      "gitrepo-1",
+			"namespace": "fleet-default",
+		},
+		"spec": map[string]any{
+			"repo": "https://github.com/example/repo1",
+			"paths": []any{
+				"charts/",
+			},
+			"targets": []any{
+				map[string]any{
+					"clusterName": "cluster-1",
+				},
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	},
+}
+
+var fakeGitRepo2 = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "fleet.cattle.io/v1alpha1",
+		"kind":       "GitRepo",
+		"metadata": map[string]any{
+			"name":      "gitrepo-2",
+			"namespace": "fleet-default",
+		},
+		"spec": map[string]any{
+			"repo": "https://github.com/example/repo2",
+			"paths": []any{
+				"manifests/",
+			},
+			"targets": []any{
+				map[string]any{
+					"clusterName": "cluster-2",
+				},
+			},
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	},
+}
+
+func listGitReposScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	return scheme
+}
+
+func TestListGitRepos(t *testing.T) {
+	fakeUrl := "https://localhost:8080"
+	fakeToken := "fakeToken"
+
+	tests := map[string]struct {
+		params         listGitRepoParams
+		fakeDynClient  *dynamicfake.FakeDynamicClient
+		expectedResult string
+		expectedError  string
+	}{
+		"list gitrepos in workspace": {
+			params: listGitRepoParams{
+				Workspace: "fleet-default",
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
+				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
+			}, fakeGitRepo1, fakeGitRepo2),
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "fleet.cattle.io/v1alpha1",
+						"kind": "GitRepo",
+						"metadata": {"name": "gitrepo-1", "namespace": "fleet-default"},
+						"spec": {
+							"repo": "https://github.com/example/repo1",
+							"paths": ["charts/"],
+							"targets": [{"clusterName": "cluster-1"}]
+						},
+						"status": {
+							"conditions": [{"type": "Ready", "status": "True"}]
+						}
+					},
+					{
+						"apiVersion": "fleet.cattle.io/v1alpha1",
+						"kind": "GitRepo",
+						"metadata": {"name": "gitrepo-2", "namespace": "fleet-default"},
+						"spec": {
+							"repo": "https://github.com/example/repo2",
+							"paths": ["manifests/"],
+							"targets": [{"clusterName": "cluster-2"}]
+						},
+						"status": {
+							"conditions": [{"type": "Ready", "status": "True"}]
+						}
+					}
+				],
+				"uiContext": [
+					{
+						"cluster": "local",
+						"kind": "GitRepo",
+						"name": "gitrepo-1",
+						"namespace": "fleet-default",
+						"type": "fleet.cattle.io.gitrepo"
+					},
+					{
+						"cluster": "local",
+						"kind": "GitRepo",
+						"name": "gitrepo-2",
+						"namespace": "fleet-default",
+						"type": "fleet.cattle.io.gitrepo"
+					}
+				]
+			}`,
+		},
+		"list gitrepos - empty workspace": {
+			params: listGitRepoParams{
+				Workspace: "empty-workspace",
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
+				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
+			}),
+			expectedResult: `{"llm": "no resources found"}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &client.Client{
+				DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
+					return test.fakeDynClient, nil
+				},
+			}
+			tools := Tools{client: c}
+
+			result, _, err := tools.listGitRepos(context.TODO(), &mcp.CallToolRequest{
+				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}, tokenHeader: {fakeToken}}},
+			}, test.params)
+
+			if test.expectedError != "" {
+				assert.ErrorContains(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.JSONEq(t, test.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+			}
+		})
+	}
+}

--- a/pkg/toolsets/fleet/tools.go
+++ b/pkg/toolsets/fleet/tools.go
@@ -1,0 +1,44 @@
+package fleet
+
+import (
+	"mcp/pkg/client"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	toolsSet    = "fleet"
+	toolsSetAnn = "toolset"
+	tokenHeader = "R_token"
+	urlHeader   = "R_url"
+)
+
+// Tools contains all tools for the MCP server
+type Tools struct {
+	client *client.Client
+}
+
+// NewTools creates and returns a new Tools instance.
+func NewTools(client *client.Client) *Tools {
+	return &Tools{
+		client: client,
+	}
+}
+
+// AddTools registers all Rancher Kubernetes tools with the provided MCP server.
+// Each tool is configured with metadata identifying it as part of the rancher toolset.
+func (t *Tools) AddTools(mcpServer *mcp.Server) {
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "listGitRepos",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `List GitRepos.
+		Parameters:
+		workspace (string, required): The workspace of the GitRepos.
+		
+		Returns:
+		List of all GitRepos in the workspace.`},
+		t.listGitRepos,
+	)
+}

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -3,6 +3,7 @@ package toolsets
 import (
 	"mcp/pkg/client"
 	"mcp/pkg/toolsets/core"
+	"mcp/pkg/toolsets/fleet"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -20,5 +21,8 @@ func AddAllTools(client *client.Client, mcpServer *mcp.Server) {
 }
 
 func allToolSets(client *client.Client) []toolsAdder {
-	return []toolsAdder{core.NewTools(client)}
+	return []toolsAdder{
+		core.NewTools(client),
+		fleet.NewTools(client),
+	}
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -12,5 +12,5 @@ func TestAllToolSets(t *testing.T) {
 	toolsets := allToolSets(client)
 
 	assert.NotNil(t, toolsets)
-	assert.Len(t, toolsets, 1, "should have exactly 1 toolset (core)")
+	assert.Len(t, toolsets, 2, "should have exactly 2 toolsets (core and fleet)")
 }


### PR DESCRIPTION
This PR introduces a new Fleet toolset, enabling Fleet MCP tools to be used by a dedicated agent in multi-agent setups.

It also adds a dedicated tool for listing all `GitRepos`. `GitRepos` cannot be retrieved via the generic `listResources` tool because they always live in the local cluster and in a namespace that matches the workspace name. Since this information cannot be inferred by the LLM, a specialized tool is required to correctly discover `GitRepos`.