### PR TITLE
rootless docker image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,4 +5,6 @@ RUN go build -o mcp
 
 FROM registry.suse.com/bci/bci-micro:15.7
 COPY --from=builder /app/mcp /mcp
+USER 1000:1000
+
 CMD ["/mcp"]


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher-ai-agent/issues/100

Update existing Dockerfiles to use rootless container images instead of root-based images. Running containers as non-root improves security by reducing the risk of privilege escalation and limiting the impact of potential vulnerabilities.

useradd is not available on bci-micro, so we use 1000 for user ID