### PR TITLE
feat: switch to non-root user

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -18,12 +18,22 @@ RUN CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o mcp
 
 FROM registry.suse.com/bci/bci-micro:15.7
 ARG VERSION=dev
+ARG UID=1000
+ARG GID=1000
 
-COPY --from=builder /src/mcp /mcp
+# Create group and user 'ai-mcp' (UID/GID 1000) with no home directory and no shell.
+RUN echo "ai-mcp:x:${GID}:" >> /etc/group && \
+    echo "ai-mcp:x:${UID}:${GID}:ai-mcp-service-user:/nonexistent:/usr/bin/false" >> /etc/passwd
+
+# Copy the binary with 750 permissions to ensure only `ai-mcp` user and group can access it.
+COPY --from=builder --chown=${UID}:${GID} --chmod=750 /src/mcp /usr/local/bin/mcp
 
 LABEL "org.opencontainers.image.title"="Rancher MCP Server." \
     "org.opencontainers.image.description"="Rancher MCP Server allows the Rancher AI agent to securely retrieve or update Kubernetes and Rancher resources across local and downstream clusters." \
     "org.opencontainers.image.source"="https://github.com/rancher/rancher-ai-mcp" \
     "org.opencontainers.image.version"=${VERSION}
 
-CMD ["/mcp"]
+# Run as `ai-mcp` user (numeric UID/GID for non-root and K8s compatibility).
+USER ${UID}:${GID}
+
+CMD ["/usr/local/bin/mcp"]


### PR DESCRIPTION
This PR supersedes: https://github.com/rancher/rancher-ai-mcp/pull/27

- Implement rootless execution by adding `ai-mcp` user (UID/GID: 1000)
- Move binary to `/usr/local/bin` instead of `/mcp` for standard compliance (this needs to be reflected in the MCP deployment as well).
- Update file ownership and set default USER to `ai-mcp`

**Note:** the securityContext could also be tightened (drop all caps, RO, no-new-priv) this will be achieved through another PR in rancher/rancher-ai-agent ([mcp deployment](https://github.com/rancher/rancher-ai-agent/blob/main/chart/agent/templates/mcp-deployment.yaml)). We should first validate that it's not too restrictive, but running the map locally with the following flags worked.

```
docker run \
  --cap-drop ALL \
  --read-only \
  --security-opt no-new-privileges:true \
  -it andypitcher/mcp:rootless
The MCP server allows the Rancher AI agent to securely retrieve
or update Kubernetes and Rancher resources across local and downstream clusters.

Usage:
  mcp [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  serve       Start the MCP server

Flags:
  -h, --help               help for mcp
      --log-level string   Set the log level (debug, info, warn, error)
  -v, --version            version for mcp

Use "mcp [command] --help" for more information about a command.
```

