### PR TITLE
Add listClusters tool

### DIFF
--- a/pkg/toolsets/core/common.go
+++ b/pkg/toolsets/core/common.go
@@ -1,0 +1,5 @@
+package core
+
+const (
+	LocalCluster = "local"
+)

--- a/pkg/toolsets/core/get_project.go
+++ b/pkg/toolsets/core/get_project.go
@@ -16,15 +16,15 @@ var zapGetProject = zap.String("tool", "getProject")
 
 type getProjectParams struct {
 	Name    string `json:"name" jsonschema:"the name of the project resource"`
-	Cluster string `json:"cluster" jsonschema:"the cluster of the project resource"`
+	Cluster string `json:"cluster" jsonschema:"the name of the cluster resource the project belongs to"`
 }
 
-// getProject retrieves a project resource.
+// getProject retrieves a project and its associated resources.
 func (t *Tools) getProject(ctx context.Context, toolReq *mcp.CallToolRequest, params getProjectParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("getProject called")
 
 	projectResource, err := t.client.GetResource(ctx, client.GetParams{
-		Cluster:   "local",
+		Cluster:   LocalCluster,
 		Kind:      "project",
 		Namespace: params.Cluster,
 		Name:      params.Name,

--- a/pkg/toolsets/core/list_clusters.go
+++ b/pkg/toolsets/core/list_clusters.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/converter"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+)
+
+var zapListClusters = zap.String("tool", "listClusters")
+
+type listClustersParams struct {
+}
+
+// listClusters retrieves a list of clusters in the management cluster.
+func (t *Tools) listClusters(ctx context.Context, toolReq *mcp.CallToolRequest, params listClustersParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("listClusters called")
+
+	resources, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster: LocalCluster,
+		Kind:    converter.ManagementClusterResourceKind,
+		URL:     t.rancherURL(toolReq),
+		Token:   middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to list clusters", zapListClusters, zap.Error(err))
+		return nil, nil, err
+	}
+
+	mcpResponse, err := response.CreateMcpResponse(resources, LocalCluster)
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zapListClusters, zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/list_clusters_test.go
+++ b/pkg/toolsets/core/list_clusters_test.go
@@ -1,0 +1,108 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestListClusters(t *testing.T) {
+	fakeUrl := "https://localhost:8080"
+	fakeToken := "fakeToken"
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = metav1.AddMetaToScheme(scheme)
+
+	customListKinds := map[schema.GroupVersionResource]string{
+		{Group: "management.cattle.io", Version: "v3", Resource: "clusters"}: "ClusterList",
+	}
+
+	t.Run("list multiple clusters", func(t *testing.T) {
+		cluster1 := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "management.cattle.io/v3",
+				"kind":       "Cluster",
+				"metadata": map[string]any{
+					"name": "cluster-1",
+				},
+			},
+		}
+
+		cluster2 := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "management.cattle.io/v3",
+				"kind":       "Cluster",
+				"metadata": map[string]any{
+					"name": "cluster-2",
+				},
+			},
+		}
+
+		fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, customListKinds, cluster1, cluster2)
+
+		c := &client.Client{
+			DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
+				return fakeDynClient, nil
+			},
+		}
+		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
+
+		result, _, err := tools.listClusters(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
+			Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
+		}, listClustersParams{})
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Len(t, result.Content, 1)
+
+		expectedResult := `{
+    "llm": [
+        {
+            "apiVersion": "management.cattle.io/v3",
+            "kind": "Cluster",
+            "metadata": {
+                "name": "cluster-1"
+            }
+        },
+        {
+            "apiVersion": "management.cattle.io/v3",
+            "kind": "Cluster",
+            "metadata": {
+                "name": "cluster-2"
+            }
+        }
+    ],
+    "uiContext": [
+        {
+            "cluster": "local",
+            "kind": "Cluster",
+            "name": "cluster-1",
+            "namespace": "",
+            "type": "management.cattle.io.cluster"
+        },
+        {
+            "cluster": "local",
+            "kind": "Cluster",
+            "name": "cluster-2",
+            "namespace": "",
+            "type": "management.cattle.io.cluster"
+        }
+    ]
+}`
+		text := result.Content[0].(*mcp.TextContent).Text
+		assert.JSONEq(t, expectedResult, text)
+	})
+}

--- a/pkg/toolsets/core/list_projects.go
+++ b/pkg/toolsets/core/list_projects.go
@@ -13,15 +13,15 @@ import (
 var zapListProjects = zap.String("tool", "listProjects")
 
 type listProjectsParams struct {
-	Cluster string `json:"cluster" jsonschema:"the cluster of the project resource"`
+	Cluster string `json:"cluster" jsonschema:"the name of the cluster resource the project belongs to"`
 }
 
-// listProjects retrieves a project resource.
+// listProjects retrieves a list of projects in a cluster.
 func (t *Tools) listProjects(ctx context.Context, toolReq *mcp.CallToolRequest, params listProjectsParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("listProjects called")
 
 	resources, err := t.client.GetResources(ctx, client.ListParams{
-		Cluster:   "local",
+		Cluster:   LocalCluster,
 		Kind:      "project",
 		Namespace: params.Cluster,
 		URL:       t.rancherURL(toolReq),

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -81,7 +81,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		
 		Example of the patch parameter:
 		[{"op": "replace", "path": "/spec/replicas", "value": 3}]`},
-		t.updateKubernetesResource)
+		t.updateKubernetesResource,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "patchKubernetesResourcePlan",
@@ -111,7 +112,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		kind (string): The type of Kubernetes resource to patch (e.g., Pod, Deployment, Service).
 		namespace (string): The namespace where the resource are located. It must be empty for all namespaces or cluster-wide resources.
 		cluster (string): The name of the Kubernetes cluster.`},
-		t.listKubernetesResources)
+		t.listKubernetesResources,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "inspectPod",
@@ -123,7 +125,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		namespace (string): The namespace where the resource are located.
 		cluster (string): The name of the Kubernetes cluster.
 		name (string): The name of the Pod.`},
-		t.inspectPod)
+		t.inspectPod,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "getDeployment",
@@ -135,7 +138,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		namespace (string): The namespace where the resource are located.
 		cluster (string): The name of the Kubernetes cluster.
 		name (string): The name of the Deployment.`},
-		t.getDeploymentDetails)
+		t.getDeploymentDetails,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "getNodeMetrics",
@@ -145,7 +149,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		Description: `Returns a list of all nodes in a specified Kubernetes cluster, including their current resource utilization metrics.'
 		Parameters:
 		cluster (string): The name of the Kubernetes cluster.`},
-		t.getNodes)
+		t.getNodes,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "createKubernetesResource",
@@ -159,7 +164,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		name (string): The name of the specific resource to patch.
 		cluster (string): The name of the Kubernetes cluster. Empty for single container pods.
 		resource (json): Resource to be created. This must be a JSON object.`},
-		t.createKubernetesResource)
+		t.createKubernetesResource,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "createKubernetesResourcePlan",
@@ -183,7 +189,8 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		Description: `Returns a list of all container images for the specified clusters.'
 		Parameters:
 		clusters (array of strings): List of clusters to get images from. Empty for return images for all clusters.`},
-		t.getClusterImages)
+		t.getClusterImages,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "getProject",
@@ -192,9 +199,10 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		},
 		Description: `Returns a project resource and its associated namespaces.'
 		Parameters:
-		name (string): The name of the project resource.
-		cluster (string): The name of the cluster the project belongs to.`},
-		t.getProject)
+		name (string): The name of the project resource. Users often use project display name instead of project resource name. When unsure if the provided name is in fact the project resource name it's best to list projects first and find the project resource name that corresponds to the project display name.
+		cluster (string): The name of the cluster resource the project belongs to. Users can often use cluster display name instead of cluster resource name. When unsure if the provided value is in fact the cluster resource name it's best to list clusters first and find the cluster resource name that corresponds to the cluster display name.`},
+		t.getProject,
+	)
 
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "listProjects",
@@ -203,6 +211,18 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		},
 		Description: `Returns a list of project resources for a specified cluster.'
 		Parameters:
-		cluster (string): The name of the cluster.`},
-		t.listProjects)
+		cluster (string): The name of the cluster resource the project belongs to. Users can often use cluster display name instead of cluster resource name. When unsure if the provided name is in fact the cluster resource name it's best to list clusters first and find the cluster resource name that corresponds to the cluster display name.`},
+		t.listProjects,
+	)
+
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "listClusters",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `Returns a list of all Rancher clusters, including local and downstream clusters.'
+		Parameters:
+		None`},
+		t.listClusters,
+	)
 }

--- a/pkg/toolsets/core/tools_test.go
+++ b/pkg/toolsets/core/tools_test.go
@@ -61,7 +61,7 @@ func TestAddTools(t *testing.T) {
 	toolsResult, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
 
 	assert.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 12, "should have 12 tools registered")
+	assert.Len(t, toolsResult.Tools, 13, "should have 13 tools registered")
 	// assert that all tools have the correct toolset annotation
 	for _, tool := range toolsResult.Tools {
 		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher-ai-agent/issues/116

This makes it possible for the agent to retrieve the list of the clusters and distinguish between the display names and cluster resource names and allows to use them interchangeably e.g. when asking to list projects.
This is also a prerequisite for the getProjectResourceUsage tool.