### PR TITLE
Add `original` and `patched` fields to patch_resource_plan result payload

### DIFF
--- a/pkg/toolsets/core/patch_resource_plan.go
+++ b/pkg/toolsets/core/patch_resource_plan.go
@@ -4,34 +4,88 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/converter"
 	"github.com/rancher/rancher-ai-mcp/pkg/response"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // updateKubernetesResourcePlan plans an update to a Kubernetes resource using a JSON patch.
-// It returns the JSON representation of the planned update without actually applying it.
-func (t *Tools) updateKubernetesResourcePlan(_ context.Context, _ *mcp.CallToolRequest, params updateKubernetesResourceParams) (*mcp.CallToolResult, any, error) {
+// It returns the original resource, the patch, and what the resource would look like after applying the patch.
+func (t *Tools) updateKubernetesResourcePlan(ctx context.Context, toolReq *mcp.CallToolRequest, params updateKubernetesResourceParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("updateKubernetesResource_plan called")
 
+	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get the original resource
+	original, err := resourceInterface.Get(ctx, params.Name, metav1.GetOptions{})
+	if err != nil {
+		zap.L().Error("failed to get original resource", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to get resource %s: %w", params.Name, err)
+	}
+
+	// Marshal the patch and original resource
 	patchBytes, err := json.Marshal(params.Patch)
 	if err != nil {
 		zap.L().Error("failed to marshal patch", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
 		return nil, nil, fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	updateResource := response.PlanResource{
-		Type:    response.OperationUpdate,
-		Payload: json.RawMessage(patchBytes),
-		Resource: response.Resource{
-			Name:      params.Name,
-			Kind:      params.Kind,
-			Cluster:   params.Cluster,
-			Namespace: params.Namespace,
+	originalBytes, err := json.Marshal(original.Object)
+	if err != nil {
+		zap.L().Error("failed to marshal original resource", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to marshal original: %w", err)
+	}
+
+	// Apply the patch to show the future state (without persisting)
+	patch, err := jsonpatch.DecodePatch(patchBytes)
+	if err != nil {
+		zap.L().Error("failed to decode patch", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to decode patch: %w", err)
+	}
+
+	patchedBytes, err := patch.Apply(originalBytes)
+	if err != nil {
+		zap.L().Error("failed to apply patch", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to apply patch: %w", err)
+	}
+
+	// Unmarshal the patched result
+	var patchedObj map[string]any
+	if err := json.Unmarshal(patchedBytes, &patchedObj); err != nil {
+		zap.L().Error("failed to unmarshal patched resource", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to unmarshal patched: %w", err)
+	}
+
+	payload := map[string]any{
+		"original": original.Object,
+		"patch":    params.Patch,
+		"patched":  patchedObj,
+	}
+
+	// Build plan resources
+	planResources := []response.PlanResource{
+		{
+			Type:    response.OperationUpdate,
+			Payload: payload,
+			Resource: response.Resource{
+				Name:      params.Name,
+				Kind:      params.Kind,
+				Cluster:   params.Cluster,
+				Namespace: params.Namespace,
+			},
 		},
 	}
-	mcpResponse, err := response.CreatePlanResponse([]response.PlanResource{updateResource})
+
+	mcpResponse, err := response.CreatePlanResponse(planResources)
 	if err != nil {
 		zap.L().Error("failed to create plan response", zap.String("tool", "updateKubernetesResource_plan"), zap.Error(err))
 		return nil, nil, err

--- a/pkg/toolsets/core/patch_resource_plan_test.go
+++ b/pkg/toolsets/core/patch_resource_plan_test.go
@@ -4,9 +4,28 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
+
+func patchResourcePlanScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	return scheme
+}
 
 func TestUpdateKubernetesResourcePlan(t *testing.T) {
 	tests := map[string]struct {
@@ -30,7 +49,11 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 			},
 			expectedResult: `[{
 				"type": "update",
-				"payload": [{"op": "add", "path": "/data/key3", "value": "value3"}],
+				"payload": {
+					"original": {"apiVersion":"v1","data":{"key1":"value1","key2":"value2"},"kind":"ConfigMap","metadata":{"name":"test-config","namespace":"default"}},
+					"patch": [{"op": "add", "path": "/data/key3", "value": "value3"}],
+					"patched": {"apiVersion":"v1","data":{"key1":"value1","key2":"value2","key3":"value3"},"kind":"ConfigMap","metadata":{"name":"test-config","namespace":"default"}}
+				},
 				"resource": {
 					"name": "test-config",
 					"kind": "ConfigMap",
@@ -55,7 +78,11 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 			},
 			expectedResult: `[{
 				"type": "update",
-				"payload": [{"op": "replace", "path": "/data/key1", "value": "updated-value"}],
+				"payload": {
+					"original": {"apiVersion":"v1","data":{"key1":"value1","key2":"value2"},"kind":"ConfigMap","metadata":{"name":"test-config","namespace":"default"}},
+					"patch": [{"op": "replace", "path": "/data/key1", "value": "updated-value"}],
+					"patched": {"apiVersion":"v1","data":{"key1":"updated-value","key2":"value2"},"kind":"ConfigMap","metadata":{"name":"test-config","namespace":"default"}}
+				},
 				"resource": {
 					"name": "test-config",
 					"kind": "ConfigMap",
@@ -79,7 +106,11 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 			},
 			expectedResult: `[{
 				"type": "update",
-				"payload": [{"op": "remove", "path": "/data/key2"}],
+				"payload": {
+					"original": {"apiVersion":"v1","data":{"key1":"value1","key2":"value2"},"kind":"ConfigMap","metadata":{"name":"test-config","namespace":"default"}},
+					"patch": [{"op": "remove", "path": "/data/key2"}],
+					"patched": {"apiVersion":"v1","data":{"key1":"value1"},"kind":"ConfigMap","metadata":{"name":"test-config","namespace":"default"}}
+				},
 				"resource": {
 					"name": "test-config",
 					"kind": "ConfigMap",
@@ -93,7 +124,7 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 				Name:      "my-deploy",
 				Namespace: "staging",
 				Kind:      "Deployment",
-				Cluster:   "downstream",
+				Cluster:   "local",
 				Patch: []jsonPatch{
 					{
 						Op:    "replace",
@@ -109,14 +140,18 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 			},
 			expectedResult: `[{
 				"type": "update",
-				"payload": [
-					{"op": "replace", "path": "/spec/replicas", "value": 3},
-					{"op": "add", "path": "/metadata/labels/env", "value": "staging"}
-				],
+				"payload": {
+					"original": {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"existing":"label"},"name":"my-deploy","namespace":"staging"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"myapp"}},"strategy":{},"template":{"metadata":{},"spec":{"containers":null}}},"status":{}},
+					"patch": [
+						{"op": "replace", "path": "/spec/replicas", "value": 3},
+						{"op": "add", "path": "/metadata/labels/env", "value": "staging"}
+					],
+					"patched": {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"env":"staging","existing":"label"},"name":"my-deploy","namespace":"staging"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"myapp"}},"strategy":{},"template":{"metadata":{},"spec":{"containers":null}}},"status":{}}
+				},
 				"resource": {
 					"name": "my-deploy",
 					"kind": "Deployment",
-					"cluster": "downstream",
+					"cluster": "local",
 					"namespace": "staging"
 				}
 			}]`,
@@ -137,7 +172,11 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 			},
 			expectedResult: `[{
 				"type": "update",
-				"payload": [{"op": "add", "path": "/metadata/labels/team", "value": "platform"}],
+				"payload": {
+					"original": {"apiVersion":"v1","kind":"Namespace","metadata":{"labels":{"existing":"label"},"name":"my-ns"},"spec":{},"status":{}},
+					"patch": [{"op": "add", "path": "/metadata/labels/team", "value": "platform"}],
+					"patched": {"apiVersion":"v1","kind":"Namespace","metadata":{"labels":{"existing":"label","team":"platform"},"name":"my-ns"},"spec":{},"status":{}}
+				},
 				"resource": {
 					"name": "my-ns",
 					"kind": "Namespace",
@@ -148,17 +187,77 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 		},
 	}
 
-	for name, test := range tests {
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			tools := Tools{}
+			var fakeClientset *fake.Clientset
+			var fakeDynClient *dynamicfake.FakeDynamicClient
 
-			result, _, err := tools.updateKubernetesResourcePlan(t.Context(), &mcp.CallToolRequest{}, test.params)
+			// Create different mock resources based on the test kind
+			if tt.params.Kind == "ConfigMap" {
+				fakeConfigMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-config",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				}
+				fakeClientset = fake.NewSimpleClientset(fakeConfigMap)
+				fakeDynClient = dynamicfake.NewSimpleDynamicClient(patchResourcePlanScheme(), fakeConfigMap)
+			} else if tt.params.Kind == "Deployment" {
+				fakeDeployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-deploy",
+						Namespace: "staging",
+						Labels:    map[string]string{"existing": "label"},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &[]int32{1}[0],
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": "myapp",
+							},
+						},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{},
+						},
+					},
+				}
+				fakeClientset = fake.NewSimpleClientset(fakeDeployment)
+				fakeDynClient = dynamicfake.NewSimpleDynamicClient(patchResourcePlanScheme(), fakeDeployment)
+			} else if tt.params.Kind == "Namespace" {
+				fakeNamespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "my-ns",
+						Labels: map[string]string{"existing": "label"},
+					},
+				}
+				fakeClientset = fake.NewSimpleClientset(fakeNamespace)
+				fakeDynClient = dynamicfake.NewSimpleDynamicClient(patchResourcePlanScheme(), fakeNamespace)
+			}
 
-			if test.expectedError != "" {
-				assert.ErrorContains(t, err, test.expectedError)
+			c := &client.Client{
+				ClientSetCreator: func(inConfig *rest.Config) (kubernetes.Interface, error) {
+					return fakeClientset, nil
+				},
+				DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
+					return fakeDynClient, nil
+				},
+			}
+
+			tools := NewTools(test.WrapClient(c, "test-token", "https://localhost:8080"), "", false)
+			req := test.NewCallToolRequest("https://localhost:8080")
+			ctx := middleware.WithToken(t.Context(), "test-token")
+
+			result, _, err := tools.updateKubernetesResourcePlan(ctx, req, tt.params)
+
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
 			} else {
 				require.NoError(t, err)
-				assert.JSONEq(t, test.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+				assert.JSONEq(t, tt.expectedResult, result.Content[0].(*mcp.TextContent).Text)
 			}
 		})
 	}


### PR DESCRIPTION
This will add more information to the planned resource updates:
- `original`: is the resource before applying the patch
- `patched`: is the resource after applying the patch

We want to use the additional fields to build the yaml-diff UI tools for the UI