### PR TITLE
chore: Create Renovate configuration file

### DIFF
--- a/.github/workflows/renovate.json
+++ b/.github/workflows/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>rancher/renovate-config#release"
+  ],
+  "baseBranchPatterns": [
+    "main"
+  ],
+  "prHourlyLimit": 2,
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
Add `.github/renovate.json` to enable automated dependency updates via Renovate.

The config:
- Extends `rancher/renovate-config#release` (shared Rancher Renovate preset)
- Targets the `main` branch
- Limits to 2 PRs/hour with a 3-day minimum release age to avoid noise
- Groups all GitHub Actions updates into a single PR