### PR TITLE
Fix JWT validation by using issuer URL

### DIFF
--- a/internal/middleware/oauth.go
+++ b/internal/middleware/oauth.go
@@ -152,10 +152,11 @@ func (c *OAuthConfig) extractToken(r *http.Request) (string, error) {
 }
 
 func (c *OAuthConfig) validateJWT(tokenString string) error {
+	issuer := strings.TrimSuffix(c.AuthorizationServerURL, "/authorize")
 	token, err := jwt.Parse(tokenString, c.jwks.Keyfunc,
 		jwt.WithValidMethods([]string{signingMethod}),
 		jwt.WithLeeway(expirationLeeway),
-		jwt.WithIssuer(c.AuthorizationServerURL),
+		jwt.WithIssuer(issuer),
 	)
 	if err != nil {
 		zap.L().Error("Failed to parse token", zap.Error(err))

--- a/internal/middleware/oauth_test.go
+++ b/internal/middleware/oauth_test.go
@@ -309,6 +309,57 @@ func TestOAuthMiddlewareInvalidIssuerCases(t *testing.T) {
 	}
 }
 
+func TestOAuthMiddlewareIssuerWithAuthorizeSuffix(t *testing.T) {
+	srv := createFakeJWKSServer(t, privateKey)
+	config := &OAuthConfig{
+		AuthorizationServerURL: testAuthServerURL + "/authorize",
+		JwksURL:                srv.URL,
+		ResourceURL:            testResourceURL,
+		SupportedScopes:        []string{testScope},
+	}
+	err := config.LoadJWKS(t.Context())
+	if err != nil {
+		t.Fatalf("Failed to initialize JWKS: %v", err)
+	}
+
+	tests := map[string]struct {
+		issuer   string
+		wantCode int
+	}{
+		"Issuer without /authorize suffix is accepted": {
+			issuer:   testAuthServerURL,
+			wantCode: http.StatusOK,
+		},
+		"Issuer with /authorize suffix is rejected": {
+			issuer:   testAuthServerURL + "/authorize",
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			claims := jwt.MapClaims{
+				"iss":   tt.issuer,
+				"aud":   config.ResourceURL,
+				"scope": []any{testScope},
+				"exp":   time.Now().Add(1 * time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			}
+			token := createTestToken(t, privateKey, claims)
+			handler := config.OAuthMiddleware(testHandler())
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Errorf("Expected status %d, got %d", tt.wantCode, rr.Code)
+			}
+		})
+	}
+}
+
 func TestOAuthMiddlewareInvalidScope(t *testing.T) {
 	config := setupTestConfig(t, privateKey)
 	// Create token with wrong scope


### PR DESCRIPTION
## Problem
We are currently using the authorization URL to validate the JWT `access_token`. However, the Rancher OIDC provider signs tokens using the issuer URL (see [Rancher source code](https://github.com/rancher/rancher/blob/main/pkg/oidc/provider/token.go#L428)), causing validation to fail.

## Solution
Switch to using the issuer URL for token validation.

Note: The issuer URL is identical to the authentication URL but without the /authorize prefix.
