### PR TITLE
Add Rancher specific RBAC tools

### DIFF
--- a/pkg/toolsets/core/get_resource.go
+++ b/pkg/toolsets/core/get_resource.go
@@ -21,7 +21,7 @@ type resourceParams struct {
 
 // getResource retrieves a specific Kubernetes resource based on the provided parameters.
 func (t *Tools) getResource(ctx context.Context, toolReq *mcp.CallToolRequest, params resourceParams) (*mcp.CallToolResult, any, error) {
-	zap.L().Debug("getKubernetesResource called")
+	zap.L().Debug("getKubernetesResource called", zap.String("resourceKind", params.Kind), zap.String("resourceName", params.Name))
 
 	resource, err := t.client.GetResource(ctx, client.GetParams{
 		Cluster:   params.Cluster,
@@ -37,7 +37,7 @@ func (t *Tools) getResource(ctx context.Context, toolReq *mcp.CallToolRequest, p
 
 	mcpResponse, err := response.CreateMcpResponse([]*unstructured.Unstructured{resource}, params.Cluster)
 	if err != nil {
-		zap.L().Error("failed to create mcp response", zap.String("tool", "listKubernetesResource"), zap.Error(err))
+		zap.L().Error("failed to create mcp response", zap.String("tool", "getKubernetesResource"), zap.Error(err))
 		return nil, nil, err
 	}
 

--- a/pkg/toolsets/core/list_resources.go
+++ b/pkg/toolsets/core/list_resources.go
@@ -26,7 +26,7 @@ type listKubernetesResourcesParams struct {
 
 // listKubernetesResources lists Kubernetes resources of a specific kind and namespace.
 func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallToolRequest, params listKubernetesResourcesParams) (*mcp.CallToolResult, any, error) {
-	zap.L().Debug("listKubernetesResource called")
+	zap.L().Debug("listKubernetesResource called", zap.String("resourceKind", params.Kind))
 
 	resources, err := t.client.GetResources(ctx, client.ListParams{
 		Cluster:       params.Cluster,

--- a/pkg/toolsets/core/rbac/common.go
+++ b/pkg/toolsets/core/rbac/common.go
@@ -1,0 +1,14 @@
+package rbac
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+func filterResourcesByField(resources []*unstructured.Unstructured, field, value string) []*unstructured.Unstructured {
+	var filteredResources []*unstructured.Unstructured
+	for _, resource := range resources {
+		resourceValue, found, err := unstructured.NestedString(resource.Object, field)
+		if err == nil && found && resourceValue == value {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+	return filteredResources
+}

--- a/pkg/toolsets/core/rbac/get_roletemplate.go
+++ b/pkg/toolsets/core/rbac/get_roletemplate.go
@@ -1,0 +1,44 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var zapGetRoleTemplate = zap.String("tool", "getRoleTemplate")
+
+type getRoleTemplateParams struct {
+	Name string `json:"name" jsonschema:"the name of the role template to retrieve"`
+}
+
+// getRoleTemplate retrieves a role template resource.
+func (t *Tools) getRoleTemplate(ctx context.Context, toolReq *mcp.CallToolRequest, params getRoleTemplateParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("getRoleTemplate called", zap.String("name", params.Name))
+
+	roleTemplate, err := t.client.GetResource(ctx, client.GetParams{
+		Cluster: "local",
+		Kind:    "roletemplate",
+		Name:    params.Name,
+		Token:   middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to get role template", zapGetRoleTemplate, zap.Error(err))
+		return nil, nil, err
+	}
+
+	mcpResponse, err := response.CreateMcpResponse([]*unstructured.Unstructured{roleTemplate}, "local")
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zapGetRoleTemplate, zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/rbac/get_roletemplate_test.go
+++ b/pkg/toolsets/core/rbac/get_roletemplate_test.go
@@ -1,0 +1,84 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetRoleTemplate(t *testing.T) {
+	rt := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "RoleTemplate",
+			"metadata": map[string]any{
+				"name": "project-owner",
+			},
+			"rules": []any{
+				map[string]any{"verbs": []any{"*"}, "resources": []any{"*"}, "apiGroups": []any{"*"}},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		params         getRoleTemplateParams
+		objects        []runtime.Object
+		expectedError  string
+		expectedResult string
+	}{
+		"get role template by name": {
+			params:  getRoleTemplateParams{Name: "project-owner"},
+			objects: []runtime.Object{rt},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "RoleTemplate",
+						"metadata": {"name": "project-owner"},
+						"rules": [{"verbs": ["*"], "resources": ["*"], "apiGroups": ["*"]}]
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "RoleTemplate", "name": "project-owner", "namespace": "", "type": "roletemplate"}
+				]
+			}`,
+		},
+		"role template not found returns error": {
+			params:        getRoleTemplateParams{Name: "nonexistent"},
+			objects:       []runtime.Object{rt},
+			expectedError: "not found",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(rbacScheme(), rbacGVRs, tt.objects...)
+			c := &client.Client{
+				DynClientCreator: func(_ *rest.Config) (dynamic.Interface, error) { return fakeDynClient, nil },
+			}
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+
+			result, _, err := tools.getRoleTemplate(
+				middleware.WithToken(t.Context(), fakeToken),
+				test.NewCallToolRequest(fakeURL),
+				tt.params,
+			)
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.JSONEq(t, tt.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+			}
+		})
+	}
+}

--- a/pkg/toolsets/core/rbac/get_user.go
+++ b/pkg/toolsets/core/rbac/get_user.go
@@ -18,7 +18,7 @@ type getUserParams struct {
 }
 
 func (t *Tools) getUser(ctx context.Context, toolReq *mcp.CallToolRequest, params getUserParams) (*mcp.CallToolResult, any, error) {
-	zap.L().Debug("getUser called", zap.String("username", params.Username))
+	zap.L().Debug("getUser called")
 
 	users, err := t.client.GetResources(ctx, client.ListParams{
 		Cluster: "local",
@@ -31,8 +31,15 @@ func (t *Tools) getUser(ctx context.Context, toolReq *mcp.CallToolRequest, param
 	}
 
 	var matchedUser []*unstructured.Unstructured
+	// We return the first user that matches either the username or the metadata.name field.
+	// It's possible that a user could have a username that matches another user's metadata.name, but this is unlikely since metadata.name is generated.
+	// We will return the first match we find in a best effort approach.
 	for _, u := range users {
 		if userName, found, err := unstructured.NestedString(u.Object, "username"); err == nil && found && userName == params.Username {
+			matchedUser = append(matchedUser, u)
+			break
+		}
+		if metadataName, found, err := unstructured.NestedString(u.Object, "metadata", "name"); err == nil && found && metadataName == params.Username {
 			matchedUser = append(matchedUser, u)
 			break
 		}

--- a/pkg/toolsets/core/rbac/get_user.go
+++ b/pkg/toolsets/core/rbac/get_user.go
@@ -1,0 +1,50 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var zapGetUser = zap.String("tool", "getUser")
+
+type getUserParams struct {
+	Username string `json:"username" jsonschema:"the username of the user to retrieve"`
+}
+
+func (t *Tools) getUser(ctx context.Context, toolReq *mcp.CallToolRequest, params getUserParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("getUser called", zap.String("username", params.Username))
+
+	users, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster: "local",
+		Kind:    "user",
+		Token:   middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to get users", zapGetUser, zap.Error(err))
+		return nil, nil, err
+	}
+
+	var matchedUser []*unstructured.Unstructured
+	for _, u := range users {
+		if userName, found, err := unstructured.NestedString(u.Object, "username"); err == nil && found && userName == params.Username {
+			matchedUser = append(matchedUser, u)
+			break
+		}
+	}
+
+	mcpResponse, err := response.CreateMcpResponse(matchedUser, "local")
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zapGetUser, zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/rbac/get_user_test.go
+++ b/pkg/toolsets/core/rbac/get_user_test.go
@@ -1,0 +1,90 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestGetUser(t *testing.T) {
+	user1 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "User",
+			"metadata": map[string]any{
+				"name": "u-abc123",
+			},
+			"username":    "admin",
+			"displayName": "Default Admin",
+		},
+	}
+	user2 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "User",
+			"metadata": map[string]any{
+				"name": "u-xyz456",
+			},
+			"username":    "jsmith",
+			"displayName": "John Smith",
+		},
+	}
+
+	tests := map[string]struct {
+		params         getUserParams
+		objects        []runtime.Object
+		expectedResult string
+	}{
+		"get user by username": {
+			params:  getUserParams{Username: "admin"},
+			objects: []runtime.Object{user1, user2},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "User",
+						"metadata": {"name": "u-abc123"},
+						"username": "admin",
+						"displayName": "Default Admin"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "User", "name": "u-abc123", "namespace": "", "type": "user"}
+				]
+			}`,
+		},
+		"no matching user returns no resources found": {
+			params:         getUserParams{Username: "nonexistent"},
+			objects:        []runtime.Object{user1, user2},
+			expectedResult: `{"llm": "no resources found"}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(rbacScheme(), rbacGVRs, tt.objects...)
+			c := &client.Client{
+				DynClientCreator: func(_ *rest.Config) (dynamic.Interface, error) { return fakeDynClient, nil },
+			}
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+
+			result, _, err := tools.getUser(
+				middleware.WithToken(t.Context(), fakeToken),
+				test.NewCallToolRequest(fakeURL),
+				tt.params,
+			)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+		})
+	}
+}

--- a/pkg/toolsets/core/rbac/list_clusterroletemplatebindings.go
+++ b/pkg/toolsets/core/rbac/list_clusterroletemplatebindings.go
@@ -15,6 +15,7 @@ var zapListClusterRoleTemplateBindings = zap.String("tool", "listClusterRoleTemp
 type listCRTBParams struct {
 	Cluster string `json:"cluster" jsonschema:"the name of the cluster the search is scoped to"`
 	User    string `json:"user,omitempty" jsonschema:"(optional) the user to get permissions for"`
+	Group   string `json:"group,omitempty" jsonschema:"(optional) the group to get permissions for"`
 }
 
 // listClusterRoleTemplateBindings retrieves a cluster role template binding resource.
@@ -43,7 +44,10 @@ func (t *Tools) listClusterRoleTemplateBindings(ctx context.Context, toolReq *mc
 	if params.User != "" {
 		crtbs = filterResourcesByField(crtbs, "userName", params.User)
 	}
-
+	// Filter the resources to only include those that match the specified group
+	if params.Group != "" {
+		crtbs = filterResourcesByField(crtbs, "groupName", params.Group)
+	}
 	mcpResponse, err := response.CreateMcpResponse(crtbs, "local")
 	if err != nil {
 		zap.L().Error("failed to create mcp response", zapListClusterRoleTemplateBindings, zap.Error(err))

--- a/pkg/toolsets/core/rbac/list_clusterroletemplatebindings.go
+++ b/pkg/toolsets/core/rbac/list_clusterroletemplatebindings.go
@@ -1,0 +1,70 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var zapListClusterRoleTemplateBindings = zap.String("tool", "listClusterRoleTemplateBindings")
+
+type listCRTBParams struct {
+	Cluster string `json:"cluster" jsonschema:"the name of the cluster the search is scoped to"`
+	User    string `json:"user,omitempty" jsonschema:"(optional) the user to get permissions for"`
+}
+
+func filterCRTBsByUser(crtbs []*unstructured.Unstructured, user string) []*unstructured.Unstructured {
+	var filteredCRTBs []*unstructured.Unstructured
+	for _, crtb := range crtbs {
+		if userName, found, err := unstructured.NestedString(crtb.Object, "userName"); err == nil && found && userName == user {
+			filteredCRTBs = append(filteredCRTBs, crtb)
+		}
+	}
+	return filteredCRTBs
+}
+
+// listClusterRoleTemplateBindings retrieves a cluster role template binding resource.
+func (t *Tools) listClusterRoleTemplateBindings(ctx context.Context, toolReq *mcp.CallToolRequest, params listCRTBParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("listClusterRoleTemplateBindings called", zap.String("cluster", params.Cluster), zap.String("user", params.User))
+
+	namespace := ""
+	if params.Cluster != "" {
+		clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
+		if err != nil {
+			zap.L().Error("failed to resolve cluster ID", zapListClusterRoleTemplateBindings, zap.Error(err))
+			return nil, nil, err
+		}
+		namespace = clusterID
+	}
+
+	crtbs, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster:   "local",
+		Kind:      "clusterroletemplatebinding",
+		Namespace: namespace,
+		Token:     middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to get cluster role template bindings", zapListClusterRoleTemplateBindings, zap.Error(err))
+		return nil, nil, err
+	}
+
+	// Filter the resources to only include those that match the specified user
+	if params.User != "" {
+		crtbs = filterCRTBsByUser(crtbs, params.User)
+	}
+
+	mcpResponse, err := response.CreateMcpResponse(crtbs, "local")
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zapListClusterRoleTemplateBindings, zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/rbac/list_clusterroletemplatebindings.go
+++ b/pkg/toolsets/core/rbac/list_clusterroletemplatebindings.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/response"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var zapListClusterRoleTemplateBindings = zap.String("tool", "listClusterRoleTemplateBindings")
@@ -18,29 +17,16 @@ type listCRTBParams struct {
 	User    string `json:"user,omitempty" jsonschema:"(optional) the user to get permissions for"`
 }
 
-func filterCRTBsByUser(crtbs []*unstructured.Unstructured, user string) []*unstructured.Unstructured {
-	var filteredCRTBs []*unstructured.Unstructured
-	for _, crtb := range crtbs {
-		if userName, found, err := unstructured.NestedString(crtb.Object, "userName"); err == nil && found && userName == user {
-			filteredCRTBs = append(filteredCRTBs, crtb)
-		}
-	}
-	return filteredCRTBs
-}
-
 // listClusterRoleTemplateBindings retrieves a cluster role template binding resource.
 func (t *Tools) listClusterRoleTemplateBindings(ctx context.Context, toolReq *mcp.CallToolRequest, params listCRTBParams) (*mcp.CallToolResult, any, error) {
-	zap.L().Debug("listClusterRoleTemplateBindings called", zap.String("cluster", params.Cluster), zap.String("user", params.User))
+	zap.L().Debug("listClusterRoleTemplateBindings called", zap.String("cluster", params.Cluster))
 
-	namespace := ""
-	if params.Cluster != "" {
-		clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
-		if err != nil {
-			zap.L().Error("failed to resolve cluster ID", zapListClusterRoleTemplateBindings, zap.Error(err))
-			return nil, nil, err
-		}
-		namespace = clusterID
+	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
+	if err != nil {
+		zap.L().Error("failed to resolve cluster ID", zapListClusterRoleTemplateBindings, zap.Error(err))
+		return nil, nil, err
 	}
+	namespace := clusterID
 
 	crtbs, err := t.client.GetResources(ctx, client.ListParams{
 		Cluster:   "local",
@@ -55,7 +41,7 @@ func (t *Tools) listClusterRoleTemplateBindings(ctx context.Context, toolReq *mc
 
 	// Filter the resources to only include those that match the specified user
 	if params.User != "" {
-		crtbs = filterCRTBsByUser(crtbs, params.User)
+		crtbs = filterResourcesByField(crtbs, "userName", params.User)
 	}
 
 	mcpResponse, err := response.CreateMcpResponse(crtbs, "local")

--- a/pkg/toolsets/core/rbac/list_clusterroletemplatebindings_test.go
+++ b/pkg/toolsets/core/rbac/list_clusterroletemplatebindings_test.go
@@ -1,0 +1,136 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestListClusterRoleTemplateBindings(t *testing.T) {
+	crtb1 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "ClusterRoleTemplateBinding",
+			"metadata": map[string]any{
+				"name":      "crtb-1",
+				"namespace": "local",
+			},
+			"clusterName":      "local",
+			"userName":         "u-user1",
+			"roleTemplateName": "cluster-owner",
+		},
+	}
+	crtb2 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "ClusterRoleTemplateBinding",
+			"metadata": map[string]any{
+				"name":      "crtb-2",
+				"namespace": "local",
+			},
+			"clusterName":      "local",
+			"userName":         "u-user2",
+			"roleTemplateName": "cluster-member",
+		},
+	}
+	crtb3 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "ClusterRoleTemplateBinding",
+			"metadata": map[string]any{
+				"name":      "crtb-3",
+				"namespace": "downstream",
+			},
+			"clusterName":      "downstream",
+			"userName":         "u-user1",
+			"roleTemplateName": "cluster-member",
+		},
+	}
+
+	tests := map[string]struct {
+		params         listCRTBParams
+		objects        []runtime.Object
+		expectedResult string
+	}{
+		"list all CRTBs for a cluster": {
+			params:  listCRTBParams{Cluster: "local"},
+			objects: []runtime.Object{crtb1, crtb2, crtb3},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ClusterRoleTemplateBinding",
+						"metadata": {"name": "crtb-1", "namespace": "local"},
+						"clusterName": "local",
+						"roleTemplateName": "cluster-owner",
+						"userName": "u-user1"
+					},
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ClusterRoleTemplateBinding",
+						"metadata": {"name": "crtb-2", "namespace": "local"},
+						"clusterName": "local",
+						"roleTemplateName": "cluster-member",
+						"userName": "u-user2"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "ClusterRoleTemplateBinding", "name": "crtb-1", "namespace": "local", "type": "clusterroletemplatebinding"},
+					{"cluster": "local", "kind": "ClusterRoleTemplateBinding", "name": "crtb-2", "namespace": "local", "type": "clusterroletemplatebinding"}
+				]
+			}`,
+		},
+		"filter by user": {
+			params:  listCRTBParams{Cluster: "local", User: "u-user1"},
+			objects: []runtime.Object{crtb1, crtb2, crtb3},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ClusterRoleTemplateBinding",
+						"metadata": {"name": "crtb-1", "namespace": "local"},
+						"clusterName": "local",
+						"roleTemplateName": "cluster-owner",
+						"userName": "u-user1"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "ClusterRoleTemplateBinding", "name": "crtb-1", "namespace": "local", "type": "clusterroletemplatebinding"}
+				]
+			}`,
+		},
+		"no CRTBs found": {
+			params:         listCRTBParams{Cluster: "local"},
+			objects:        []runtime.Object{},
+			expectedResult: `{"llm": "no resources found"}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(rbacScheme(), rbacGVRs, tt.objects...)
+			c := &client.Client{
+				DynClientCreator: func(_ *rest.Config) (dynamic.Interface, error) { return fakeDynClient, nil },
+			}
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+
+			result, _, err := tools.listClusterRoleTemplateBindings(
+				middleware.WithToken(t.Context(), fakeToken),
+				test.NewCallToolRequest(fakeURL),
+				tt.params,
+			)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+		})
+	}
+}

--- a/pkg/toolsets/core/rbac/list_projectroletemplatebindings.go
+++ b/pkg/toolsets/core/rbac/list_projectroletemplatebindings.go
@@ -1,0 +1,99 @@
+package rbac
+
+import (
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var zapListProjectRoleTemplateBindings = zap.String("tool", "listProjectRoleTemplateBindings")
+
+type listPRTBParams struct {
+	Cluster   string `json:"cluster" jsonschema:"the name or ID of the cluster resource the project belongs to"`
+	ProjectID string `json:"projectID,omitempty" jsonschema:"(optional) the ID of the project resource (e.g. p-abc)"`
+	User      string `json:"user,omitempty" jsonschema:"(optional) the user to get permissions for"`
+}
+
+func filterPRTBsByUser(prtbs []*unstructured.Unstructured, user string) []*unstructured.Unstructured {
+	var filteredPRTBs []*unstructured.Unstructured
+	for _, prtb := range prtbs {
+		if userName, found, err := unstructured.NestedString(prtb.Object, "userName"); err == nil && found && userName == user {
+			filteredPRTBs = append(filteredPRTBs, prtb)
+		}
+	}
+	return filteredPRTBs
+}
+
+func filterPRTBsByCluster(prtbs []*unstructured.Unstructured, clusterName string) []*unstructured.Unstructured {
+	var filteredPRTBs []*unstructured.Unstructured
+	for _, prtb := range prtbs {
+		projectNameField, found, err := unstructured.NestedString(prtb.Object, "projectName")
+		if err != nil || !found {
+			zap.L().Error("failed to get projectName from PRTB", zapListProjectRoleTemplateBindings, zap.Error(err))
+		}
+		cluster, _, found := strings.Cut(projectNameField, ":")
+		if !found || cluster != clusterName {
+			continue
+		}
+		filteredPRTBs = append(filteredPRTBs, prtb)
+	}
+	return filteredPRTBs
+}
+
+// listProjectRoleTemplateBindings retrieves a project role template binding resource.
+func (t *Tools) listProjectRoleTemplateBindings(ctx context.Context, toolReq *mcp.CallToolRequest, params listPRTBParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("listProjectRoleTemplateBindings called", zap.String("cluster", params.Cluster), zap.String("projectID", params.ProjectID), zap.String("user", params.User))
+
+	clusterID := params.Cluster
+	if params.Cluster != "" {
+		var err error
+		clusterID, err = t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
+		if err != nil {
+			zap.L().Error("failed to resolve cluster ID", zapListProjectRoleTemplateBindings, zap.Error(err))
+			return nil, nil, err
+		}
+	}
+
+	namespace := ""
+	if params.ProjectID != "" {
+		projectBackingNamespace := clusterID + "-" + params.ProjectID
+		namespace = projectBackingNamespace
+	}
+
+	prtbs, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster:   "local",
+		Kind:      "projectroletemplatebinding",
+		Namespace: namespace,
+		Token:     middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to get project role template bindings", zapListProjectRoleTemplateBindings, zap.Error(err))
+		return nil, nil, err
+	}
+
+	// Filter the resources to only include those that match the specified user
+	if params.User != "" {
+		prtbs = filterPRTBsByUser(prtbs, params.User)
+	}
+
+	// Filter the resources to only include those that match the specified cluster
+	if clusterID != "" {
+		prtbs = filterPRTBsByCluster(prtbs, clusterID)
+	}
+
+	mcpResponse, err := response.CreateMcpResponse(prtbs, "local")
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zapListProjectRoleTemplateBindings, zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/rbac/list_projectroletemplatebindings.go
+++ b/pkg/toolsets/core/rbac/list_projectroletemplatebindings.go
@@ -18,16 +18,7 @@ type listPRTBParams struct {
 	Cluster   string `json:"cluster" jsonschema:"the name or ID of the cluster resource the project belongs to"`
 	ProjectID string `json:"projectID,omitempty" jsonschema:"(optional) the ID of the project resource (e.g. p-abc)"`
 	User      string `json:"user,omitempty" jsonschema:"(optional) the user to get permissions for"`
-}
-
-func filterPRTBsByUser(prtbs []*unstructured.Unstructured, user string) []*unstructured.Unstructured {
-	var filteredPRTBs []*unstructured.Unstructured
-	for _, prtb := range prtbs {
-		if userName, found, err := unstructured.NestedString(prtb.Object, "userName"); err == nil && found && userName == user {
-			filteredPRTBs = append(filteredPRTBs, prtb)
-		}
-	}
-	return filteredPRTBs
+	Group     string `json:"group,omitempty" jsonschema:"(optional) the group to get permissions for"`
 }
 
 func filterPRTBsByCluster(prtbs []*unstructured.Unstructured, clusterName string) []*unstructured.Unstructured {
@@ -48,16 +39,12 @@ func filterPRTBsByCluster(prtbs []*unstructured.Unstructured, clusterName string
 
 // listProjectRoleTemplateBindings retrieves a project role template binding resource.
 func (t *Tools) listProjectRoleTemplateBindings(ctx context.Context, toolReq *mcp.CallToolRequest, params listPRTBParams) (*mcp.CallToolResult, any, error) {
-	zap.L().Debug("listProjectRoleTemplateBindings called", zap.String("cluster", params.Cluster), zap.String("projectID", params.ProjectID), zap.String("user", params.User))
+	zap.L().Debug("listProjectRoleTemplateBindings called", zap.String("cluster", params.Cluster), zap.String("projectID", params.ProjectID))
 
-	clusterID := params.Cluster
-	if params.Cluster != "" {
-		var err error
-		clusterID, err = t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
-		if err != nil {
-			zap.L().Error("failed to resolve cluster ID", zapListProjectRoleTemplateBindings, zap.Error(err))
-			return nil, nil, err
-		}
+	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
+	if err != nil {
+		zap.L().Error("failed to resolve cluster ID", zapListProjectRoleTemplateBindings, zap.Error(err))
+		return nil, nil, err
 	}
 
 	namespace := ""
@@ -79,7 +66,10 @@ func (t *Tools) listProjectRoleTemplateBindings(ctx context.Context, toolReq *mc
 
 	// Filter the resources to only include those that match the specified user
 	if params.User != "" {
-		prtbs = filterPRTBsByUser(prtbs, params.User)
+		prtbs = filterResourcesByField(prtbs, "userName", params.User)
+	}
+	if params.Group != "" {
+		prtbs = filterResourcesByField(prtbs, "groupName", params.Group)
 	}
 
 	// Filter the resources to only include those that match the specified cluster

--- a/pkg/toolsets/core/rbac/list_projectroletemplatebindings_test.go
+++ b/pkg/toolsets/core/rbac/list_projectroletemplatebindings_test.go
@@ -1,0 +1,201 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestListProjectRoleTemplateBindings(t *testing.T) {
+	prtb1 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "ProjectRoleTemplateBinding",
+			"metadata": map[string]any{
+				"name":      "prtb-1",
+				"namespace": "local-p-abc",
+			},
+			"projectName":      "local:p-abc",
+			"userName":         "u-user1",
+			"roleTemplateName": "project-owner",
+		},
+	}
+	prtb2 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "ProjectRoleTemplateBinding",
+			"metadata": map[string]any{
+				"name":      "prtb-2",
+				"namespace": "local-p-abc",
+			},
+			"projectName":      "local:p-abc",
+			"userName":         "u-user2",
+			"roleTemplateName": "project-member",
+		},
+	}
+	prtb3 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "ProjectRoleTemplateBinding",
+			"metadata": map[string]any{
+				"name":      "prtb-3",
+				"namespace": "local-p-xyz",
+			},
+			"projectName":      "local:p-xyz",
+			"userName":         "u-user1",
+			"roleTemplateName": "project-member",
+		},
+	}
+
+	tests := map[string]struct {
+		params         listPRTBParams
+		objects        []runtime.Object
+		expectedResult string
+	}{
+		"list all PRTBs for a cluster": {
+			params:  listPRTBParams{Cluster: "local"},
+			objects: []runtime.Object{prtb1, prtb2, prtb3},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-1", "namespace": "local-p-abc"},
+						"projectName": "local:p-abc",
+						"roleTemplateName": "project-owner",
+						"userName": "u-user1"
+					},
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-2", "namespace": "local-p-abc"},
+						"projectName": "local:p-abc",
+						"roleTemplateName": "project-member",
+						"userName": "u-user2"
+					},
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-3", "namespace": "local-p-xyz"},
+						"projectName": "local:p-xyz",
+						"roleTemplateName": "project-member",
+						"userName": "u-user1"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-1", "namespace": "local-p-abc", "type": "projectroletemplatebinding"},
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-2", "namespace": "local-p-abc", "type": "projectroletemplatebinding"},
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-3", "namespace": "local-p-xyz", "type": "projectroletemplatebinding"}
+				]
+			}`,
+		},
+		"filter by project": {
+			params:  listPRTBParams{Cluster: "local", ProjectID: "p-abc"},
+			objects: []runtime.Object{prtb1, prtb2, prtb3},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-1", "namespace": "local-p-abc"},
+						"projectName": "local:p-abc",
+						"roleTemplateName": "project-owner",
+						"userName": "u-user1"
+					},
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-2", "namespace": "local-p-abc"},
+						"projectName": "local:p-abc",
+						"roleTemplateName": "project-member",
+						"userName": "u-user2"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-1", "namespace": "local-p-abc", "type": "projectroletemplatebinding"},
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-2", "namespace": "local-p-abc", "type": "projectroletemplatebinding"}
+				]
+			}`,
+		},
+		"filter by user": {
+			params:  listPRTBParams{Cluster: "local", User: "u-user1"},
+			objects: []runtime.Object{prtb1, prtb2, prtb3},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-1", "namespace": "local-p-abc"},
+						"projectName": "local:p-abc",
+						"roleTemplateName": "project-owner",
+						"userName": "u-user1"
+					},
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-3", "namespace": "local-p-xyz"},
+						"projectName": "local:p-xyz",
+						"roleTemplateName": "project-member",
+						"userName": "u-user1"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-1", "namespace": "local-p-abc", "type": "projectroletemplatebinding"},
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-3", "namespace": "local-p-xyz", "type": "projectroletemplatebinding"}
+				]
+			}`,
+		},
+		"filter by project and user": {
+			params:  listPRTBParams{Cluster: "local", ProjectID: "p-abc", User: "u-user1"},
+			objects: []runtime.Object{prtb1, prtb2, prtb3},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "ProjectRoleTemplateBinding",
+						"metadata": {"name": "prtb-1", "namespace": "local-p-abc"},
+						"projectName": "local:p-abc",
+						"roleTemplateName": "project-owner",
+						"userName": "u-user1"
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "ProjectRoleTemplateBinding", "name": "prtb-1", "namespace": "local-p-abc", "type": "projectroletemplatebinding"}
+				]
+			}`,
+		},
+		"no PRTBs found": {
+			params:         listPRTBParams{Cluster: "local"},
+			objects:        []runtime.Object{},
+			expectedResult: `{"llm": "no resources found"}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(rbacScheme(), rbacGVRs, tt.objects...)
+			c := &client.Client{
+				DynClientCreator: func(_ *rest.Config) (dynamic.Interface, error) { return fakeDynClient, nil },
+			}
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+
+			result, _, err := tools.listProjectRoleTemplateBindings(
+				middleware.WithToken(t.Context(), fakeToken),
+				test.NewCallToolRequest(fakeURL),
+				tt.params,
+			)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+		})
+	}
+}

--- a/pkg/toolsets/core/rbac/list_roletemplates.go
+++ b/pkg/toolsets/core/rbac/list_roletemplates.go
@@ -12,7 +12,7 @@ import (
 
 var zapListRoleTemplates = zap.String("tool", "listRoleTemplates")
 
-// listRoleTemplates retrieves a role template resource.
+// listRoleTemplates lists role template resources.
 func (t *Tools) listRoleTemplates(ctx context.Context, toolReq *mcp.CallToolRequest, params struct{}) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("listRoleTemplates called")
 

--- a/pkg/toolsets/core/rbac/list_roletemplates.go
+++ b/pkg/toolsets/core/rbac/list_roletemplates.go
@@ -1,0 +1,38 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+)
+
+var zapListRoleTemplates = zap.String("tool", "listRoleTemplates")
+
+// listRoleTemplates retrieves a role template resource.
+func (t *Tools) listRoleTemplates(ctx context.Context, toolReq *mcp.CallToolRequest, params struct{}) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("listRoleTemplates called")
+
+	roleTemplates, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster: "local",
+		Kind:    "roletemplate",
+		Token:   middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to list role templates", zapListRoleTemplates, zap.Error(err))
+		return nil, nil, err
+	}
+
+	mcpResponse, err := response.CreateMcpResponse(roleTemplates, "local")
+	if err != nil {
+		zap.L().Error("failed to create mcp response", zapListRoleTemplates, zap.Error(err))
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/rbac/list_roletemplates_test.go
+++ b/pkg/toolsets/core/rbac/list_roletemplates_test.go
@@ -1,0 +1,95 @@
+package rbac
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestListRoleTemplates(t *testing.T) {
+	rt1 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "RoleTemplate",
+			"metadata": map[string]any{
+				"name": "project-owner",
+			},
+			"rules": []any{
+				map[string]any{"verbs": []any{"*"}, "resources": []any{"*"}, "apiGroups": []any{"*"}},
+			},
+		},
+	}
+	rt2 := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "RoleTemplate",
+			"metadata": map[string]any{
+				"name": "project-member",
+			},
+			"rules": []any{
+				map[string]any{"verbs": []any{"get", "list"}, "resources": []any{"pods"}, "apiGroups": []any{""}},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		objects        []runtime.Object
+		expectedResult string
+	}{
+		"list multiple role templates": {
+			objects: []runtime.Object{rt1, rt2},
+			expectedResult: `{
+				"llm": [
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "RoleTemplate",
+						"metadata": {"name": "project-member"},
+						"rules": [{"verbs": ["get", "list"], "resources": ["pods"], "apiGroups": [""]}]
+					},
+					{
+						"apiVersion": "management.cattle.io/v3",
+						"kind": "RoleTemplate",
+						"metadata": {"name": "project-owner"},
+						"rules": [{"verbs": ["*"], "resources": ["*"], "apiGroups": ["*"]}]
+					}
+				],
+				"uiContext": [
+					{"cluster": "local", "kind": "RoleTemplate", "name": "project-member", "namespace": "", "type": "roletemplate"},
+					{"cluster": "local", "kind": "RoleTemplate", "name": "project-owner", "namespace": "", "type": "roletemplate"}
+				]
+			}`,
+		},
+		"no role templates": {
+			objects:        []runtime.Object{},
+			expectedResult: `{"llm": "no resources found"}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(rbacScheme(), rbacGVRs, tt.objects...)
+			c := &client.Client{
+				DynClientCreator: func(_ *rest.Config) (dynamic.Interface, error) { return fakeDynClient, nil },
+			}
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+
+			result, _, err := tools.listRoleTemplates(
+				middleware.WithToken(t.Context(), fakeToken),
+				test.NewCallToolRequest(fakeURL),
+				struct{}{},
+			)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expectedResult, result.Content[0].(*mcp.TextContent).Text)
+		})
+	}
+}

--- a/pkg/toolsets/core/rbac/tools.go
+++ b/pkg/toolsets/core/rbac/tools.go
@@ -1,0 +1,87 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	toolsSet    = "rancher"
+	toolsSetAnn = "toolset"
+)
+
+type toolsClient interface {
+	GetClusterID(ctx context.Context, token string, clusterNameOrID string) (string, error)
+	GetResource(ctx context.Context, params client.GetParams) (*unstructured.Unstructured, error)
+	GetResources(ctx context.Context, params client.ListParams) ([]*unstructured.Unstructured, error)
+	GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error)
+}
+
+// Tools contains tools for interacting with RBAC in Rancher.
+type Tools struct {
+	client   toolsClient
+	ReadOnly bool
+}
+
+// NewTools creates and returns a new Tools instance.
+func NewTools(client toolsClient, readOnly bool) *Tools {
+	return &Tools{
+		client:   client,
+		ReadOnly: readOnly,
+	}
+}
+
+// AddTools registers all RBAC tools with the provided MCP server.
+func (t *Tools) AddTools(mcpServer *mcp.Server) {
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "listClusterRoleTemplateBindings",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `List all cluster role template bindings (CRTBs) in a Rancher cluster.
+		If a user ID is specified only returns CRTBs for that user.
+		CRTBs provide users permissions as specified by a RoleTemplate at the cluster level.`},
+		t.listClusterRoleTemplateBindings,
+	)
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "listProjectRoleTemplateBindings",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `List all project role template bindings (PRTBs) in a Rancher cluster.
+		If a user ID is specified only returns PRTBs for that user.
+		If a project ID is specified only returns PRTBs for that project.
+		PRTBs provide users permissions as specified by a RoleTemplate in a project.`},
+		t.listProjectRoleTemplateBindings,
+	)
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "listRoleTemplates",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `List all role templates in a Rancher cluster.
+		Role templates define a set of permissions that can be assigned to users or groups.`},
+		t.listRoleTemplates,
+	)
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "getUser",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `Get a user ID by username.`},
+		t.getUser,
+	)
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name: "getRoleTemplate",
+		Meta: map[string]any{
+			toolsSetAnn: toolsSet,
+		},
+		Description: `Get a role template by name.`},
+		t.getRoleTemplate,
+	)
+}

--- a/pkg/toolsets/core/rbac/tools_test.go
+++ b/pkg/toolsets/core/rbac/tools_test.go
@@ -1,0 +1,96 @@
+package rbac
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	fakeURL   = "https://localhost:8080"
+	fakeToken = "fakeToken"
+)
+
+var rbacGVRs = map[schema.GroupVersionResource]string{
+	{Group: "management.cattle.io", Version: "v3", Resource: "clusterroletemplatebindings"}: "ClusterRoleTemplateBindingList",
+	{Group: "management.cattle.io", Version: "v3", Resource: "projectroletemplatebindings"}: "ProjectRoleTemplateBindingList",
+	{Group: "management.cattle.io", Version: "v3", Resource: "roletemplates"}:               "RoleTemplateList",
+	{Group: "management.cattle.io", Version: "v3", Resource: "users"}:                       "UserList",
+}
+
+func rbacScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = metav1.AddMetaToScheme(scheme)
+	return scheme
+}
+
+func startMCPServer(t *testing.T, tools *Tools) (*mcp.ClientSession, func()) {
+	t.Helper()
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "v1.0.0"}, nil)
+	tools.AddTools(mcpServer)
+
+	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server { return mcpServer }, &mcp.StreamableHTTPOptions{})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &http.Server{Handler: handler}
+	go server.Serve(listener)
+
+	var cs *mcp.ClientSession
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "mcp-client", Version: "v1.0.0"}, nil)
+	transport := &mcp.StreamableClientTransport{Endpoint: "http://" + listener.Addr().String()}
+
+	assert.Eventually(t, func() bool {
+		cs, err = mcpClient.Connect(context.Background(), transport, nil)
+		return err == nil
+	}, 2*time.Second, 100*time.Millisecond)
+
+	require.NotNil(t, cs)
+	return cs, func() {
+		cs.Close()
+		server.Shutdown(context.Background())
+		listener.Close()
+	}
+}
+
+func TestAddTools(t *testing.T) {
+	c, err := client.NewClient(true, "")
+	require.NoError(t, err)
+	cs, cleanup := startMCPServer(t, NewTools(c, false))
+	defer cleanup()
+
+	toolsResult, err := cs.ListTools(context.Background(), &mcp.ListToolsParams{})
+	assert.NoError(t, err)
+	assert.Len(t, toolsResult.Tools, 5, "incorrect number of RBAC tools registered")
+	for _, tool := range toolsResult.Tools {
+		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+	}
+}
+
+func TestAddToolsReadOnly(t *testing.T) {
+	c, err := client.NewClient(true, "")
+	require.NoError(t, err)
+	cs, cleanup := startMCPServer(t, NewTools(c, true))
+	defer cleanup()
+
+	toolsResult, err := cs.ListTools(context.Background(), &mcp.ListToolsParams{})
+	assert.NoError(t, err)
+	assert.Len(t, toolsResult.Tools, 5, "incorrect number of RBAC tools registered in read-only mode")
+	for _, tool := range toolsResult.Tools {
+		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+	}
+}

--- a/pkg/toolsets/core/rbac/tools_test.go
+++ b/pkg/toolsets/core/rbac/tools_test.go
@@ -68,7 +68,7 @@ func startMCPServer(t *testing.T, tools *Tools) (*mcp.ClientSession, func()) {
 }
 
 func TestAddTools(t *testing.T) {
-	c, err := client.NewClient(true, "")
+	c, err := client.NewClient(true, fakeURL)
 	require.NoError(t, err)
 	cs, cleanup := startMCPServer(t, NewTools(c, false))
 	defer cleanup()
@@ -82,7 +82,7 @@ func TestAddTools(t *testing.T) {
 }
 
 func TestAddToolsReadOnly(t *testing.T) {
-	c, err := client.NewClient(true, "")
+	c, err := client.NewClient(true, fakeURL)
 	require.NoError(t, err)
 	cs, cleanup := startMCPServer(t, NewTools(c, true))
 	defer cleanup()

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -6,6 +6,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/core/projects"
+	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/core/rbac"
 	"github.com/rancher/rancher-ai-mcp/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -117,6 +118,8 @@ Results are paginated with limit (page size, default 100) and offset (how many r
 	)
 
 	projects.NewTools(t.client, t.ReadOnly).AddTools(mcpServer)
+
+	rbac.NewTools(t.client, t.ReadOnly).AddTools(mcpServer)
 
 	if !t.ReadOnly {
 		mcp.AddTool(mcpServer, &mcp.Tool{

--- a/pkg/toolsets/core/tools_test.go
+++ b/pkg/toolsets/core/tools_test.go
@@ -62,7 +62,7 @@ func TestAddTools(t *testing.T) {
 	toolsResult, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
 
 	assert.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 16, "incorrect number of tools registered")
+	assert.Len(t, toolsResult.Tools, 21, "incorrect number of tools registered")
 	// assert that all tools have the correct toolset annotation
 	for _, tool := range toolsResult.Tools {
 		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
@@ -116,7 +116,7 @@ func TestAddToolsReadOnly(t *testing.T) {
 	toolsResult, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
 
 	assert.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 10, "read-only mode should not register mutating tools")
+	assert.Len(t, toolsResult.Tools, 15, "read-only mode should not register mutating tools")
 
 	toolNames := make(map[string]bool)
 	for _, tool := range toolsResult.Tools {

--- a/pkg/toolsets/provisioning/analyze_cluster.go
+++ b/pkg/toolsets/provisioning/analyze_cluster.go
@@ -140,13 +140,13 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 			zap.Int("machineDeployments", len(machineDeployments)))
 	}
 
-	if machines != nil && len(machines) > 0 {
+	if len(machines) > 0 {
 		resources = append(resources, machines...)
 	}
-	if machineSets != nil && len(machineSets) > 0 {
+	if len(machineSets) > 0 {
 		resources = append(resources, machineSets...)
 	}
-	if machineDeployments != nil && len(machineDeployments) > 0 {
+	if len(machineDeployments) > 0 {
 		resources = append(resources, machineDeployments...)
 	}
 

--- a/pkg/toolsets/provisioning/analyze_cluster_machines.go
+++ b/pkg/toolsets/provisioning/analyze_cluster_machines.go
@@ -39,15 +39,15 @@ func (t *Tools) analyzeClusterMachines(ctx context.Context, toolReq *mcp.CallToo
 	}
 
 	var resources []*unstructured.Unstructured
-	if machines != nil && len(machines) > 0 {
+	if len(machines) > 0 {
 		resources = append(resources, machines...)
 	}
 
-	if machineSets != nil && len(machineSets) > 0 {
+	if len(machineSets) > 0 {
 		resources = append(resources, machineSets...)
 	}
 
-	if machineDeployments != nil && len(machineDeployments) > 0 {
+	if len(machineDeployments) > 0 {
 		resources = append(resources, machineDeployments...)
 	}
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher-ai-agent/issues/54

This adds new MCP tools designed to get Rancher RBAC resources. This way Liz can read a user's permissions. Does not introduce any edit/create/delete capabilities as these are security related resources.

The tools introduced are:
- get RoleTemplate
- get User
- list CRTB
- list PRTB
- list RoleTemplate