### PR TITLE
Use internal Rancher url

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/dynamiclistener"
@@ -55,32 +54,14 @@ func init() {
 	serveCmd.Flags().StringVar(&resourceURL, "resource-url", "", "Resource URL for this server - this should be the address to access the MCP server")
 }
 
-func rancherURLFromAuthServerURL(s string) (string, error) {
-	if s == "" {
-		return "", nil
-	}
-	parsed, err := url.Parse(s)
-	if err != nil {
-		return "", err
-	}
-
-	parsed.Path = ""
-	parsed.RawQuery = ""
-	parsed.Fragment = ""
-
-	return parsed.String(), nil
-}
-
 func runServe(cmd *cobra.Command, args []string) error {
 	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "rancher mcp server", Version: "v1.0.0"}, nil)
-	client := client.NewClient(insecure)
-
-	rancherURL, err := rancherURLFromAuthServerURL(authzServerURL)
+	client, err := client.NewClient(insecure, authzServerURL)
 	if err != nil {
-		return fmt.Errorf("parsing authz-server-url: %w", err)
+		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	toolsets.AddAllTools(client, mcpServer, rancherURL, readOnly)
+	toolsets.AddAllTools(client, mcpServer, readOnly)
 
 	zap.L().Info("read-only mode", zap.Bool("enabled", readOnly))
 
@@ -88,7 +69,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return mcpServer
 	}, &mcp.StreamableHTTPOptions{})
 
-	zap.L().Info("Rancher Server", zap.String("url", rancherURL), zap.String("authzServerURL", authzServerURL))
 	oauthConfig := middleware.NewOAuthConfig(authzServerURL, jwksURL, resourceURL, []string{"offline_access", "rancher:mcp"})
 	if insecure {
 		oauthConfig.InsecureTLS = true

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -8,53 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRancherURLFromAuthServerURL(t *testing.T) {
-	testCases := map[string]struct {
-		input    string
-		expected string
-		wantErr  bool
-	}{
-		"empty input returns empty string": {
-			input:    "",
-			expected: "",
-			wantErr:  false,
-		},
-		"removes path query and fragment": {
-			input:    "https://rancher.example.com/v3-public/auth?scope=openid#section",
-			expected: "https://rancher.example.com",
-			wantErr:  false,
-		},
-		"keeps scheme host and port": {
-			input:    "https://rancher.example.com:9443/oauth2/authorize",
-			expected: "https://rancher.example.com:9443",
-			wantErr:  false,
-		},
-		"strips trailing slash-only path": {
-			input:    "https://rancher.example.com/",
-			expected: "https://rancher.example.com",
-			wantErr:  false,
-		},
-		"invalid URL returns error": {
-			input:   "http://[::1",
-			wantErr: true,
-		},
-	}
-
-	for name, tt := range testCases {
-		t.Run(name, func(t *testing.T) {
-			actual, err := rancherURLFromAuthServerURL(tt.input)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
 func TestServeCmd(t *testing.T) {
 	assert.NotNil(t, serveCmd)
 	assert.Equal(t, "serve", serveCmd.Use)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -24,6 +25,7 @@ var clustersDisplayNameToIDCache = sync.Map{}
 // Client is a struct that provides methods for interacting with Kubernetes clusters.
 type Client struct {
 	insecure         bool
+	rancherURL       string
 	DynClientCreator func(*rest.Config) (dynamic.Interface, error)
 	ClientSetCreator func(*rest.Config) (kubernetes.Interface, error)
 }
@@ -34,7 +36,6 @@ type GetParams struct {
 	Kind      string // The Kind of the Kubernetes resource (e.g., "pod", "deployment").
 	Namespace string // The Namespace of the resource (optional).
 	Name      string // The Name of the resource (optional).
-	URL       string // The base URL of the Rancher server.
 	Token     string // The authentication Token for Steve.
 }
 
@@ -44,32 +45,46 @@ type ListParams struct {
 	Kind          string // The Kind of the Kubernetes resource (e.g., "pod", "deployment").
 	Namespace     string // The Namespace of the resource (optional).
 	Name          string // The Name of the resource (optional).
-	URL           string // The base URL of the Rancher server.
 	Token         string // The authentication Token for Steve.
 	LabelSelector string // Optional LabelSelector string for the request.
 	Limit         int64  // Optional maximum number of resources to return. 0 means no limit.
 }
 
 // NewClient creates and returns a new instance of the Client struct.
-func NewClient(insecure bool) *Client {
+func NewClient(insecure bool, authzServerURL string) (*Client, error) {
+	rancherURL, err := rancherURLFromAuthServerURL(authzServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing authz-server-url: %w", err)
+	}
+	if rancherURL == "" {
+		rancherURL = "https://rancher.cattle-system"
+		if insecure {
+			rancherURL = "http://rancher.cattle-system"
+		}
+	}
 	return &Client{
-		insecure: insecure,
+		insecure:   insecure,
+		rancherURL: rancherURL,
 		DynClientCreator: func(cfg *rest.Config) (dynamic.Interface, error) {
 			return dynamic.NewForConfig(cfg)
 		},
 		ClientSetCreator: func(cfg *rest.Config) (kubernetes.Interface, error) {
 			return kubernetes.NewForConfig(cfg)
 		},
-	}
+	}, nil
+}
+
+func (c *Client) RancherURL() string {
+	return c.rancherURL
 }
 
 // CreateClientSet creates a new Kubernetes clientset for the given Token and URL.
-func (c *Client) CreateClientSet(ctx context.Context, token string, url string, cluster string) (kubernetes.Interface, error) {
-	clusterID, err := c.GetClusterID(ctx, token, url, cluster)
+func (c *Client) CreateClientSet(ctx context.Context, token string, cluster string) (kubernetes.Interface, error) {
+	clusterID, err := c.GetClusterID(ctx, token, cluster)
 	if err != nil {
 		return nil, err
 	}
-	restConfig, err := c.CreateRestConfig(token, url, clusterID)
+	restConfig, err := c.CreateRestConfig(token, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -78,12 +93,12 @@ func (c *Client) CreateClientSet(ctx context.Context, token string, url string, 
 }
 
 // GetResourceInterface returns a dynamic resource interface for the given Token, URL, Namespace, and GroupVersionResource.
-func (c *Client) GetResourceInterface(ctx context.Context, token string, url string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
-	clusterID, err := c.GetClusterID(ctx, token, url, cluster)
+func (c *Client) GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
+	clusterID, err := c.GetClusterID(ctx, token, cluster)
 	if err != nil {
 		return nil, err
 	}
-	restConfig, err := c.CreateRestConfig(token, url, clusterID)
+	restConfig, err := c.CreateRestConfig(token, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +117,7 @@ func (c *Client) GetResourceInterface(ctx context.Context, token string, url str
 // GetResource retrieves a single Kubernetes resource by name.
 // It returns the resource as an unstructured object or an error if the resource is not found.
 func (c *Client) GetResource(ctx context.Context, params GetParams) (*unstructured.Unstructured, error) {
-	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.URL, params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
+	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +131,7 @@ func (c *Client) GetResource(ctx context.Context, params GetParams) (*unstructur
 }
 
 func (c *Client) GetResourceByGVR(ctx context.Context, params GetParams, gvr schema.GroupVersionResource) (*unstructured.Unstructured, error) {
-	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.URL, params.Namespace, params.Cluster, gvr)
+	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.Namespace, params.Cluster, gvr)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +153,7 @@ func (c *Client) GetResourceAtAnyAPIVersion(ctx context.Context, params GetParam
 		return nil, fmt.Errorf("unknown kind: %s", params.Kind)
 	}
 
-	versions, err := c.getAPIVersionsForGR(ctx, params.Token, params.URL, params.Cluster, schema.GroupResource{
+	versions, err := c.getAPIVersionsForGR(ctx, params.Token, params.Cluster, schema.GroupResource{
 		Group:    currentGVK.Group,
 		Resource: currentGVK.Resource,
 	})
@@ -149,7 +164,7 @@ func (c *Client) GetResourceAtAnyAPIVersion(ctx context.Context, params GetParam
 	var item *unstructured.Unstructured
 	for _, version := range versions {
 		currentGVK.Version = version
-		resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.URL, params.Namespace, params.Cluster, currentGVK)
+		resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.Namespace, params.Cluster, currentGVK)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +192,7 @@ func (c *Client) GetResourceAtAnyAPIVersion(ctx context.Context, params GetParam
 // GetResources lists Kubernetes resources matching the provided parameters.
 // It supports optional label selectors for filtering and returns a slice of unstructured objects.
 func (c *Client) GetResources(ctx context.Context, params ListParams) ([]*unstructured.Unstructured, error) {
-	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.URL, params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
+	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +226,7 @@ func (c *Client) GetResourcesAtAnyAPIVersion(ctx context.Context, params ListPar
 		return nil, fmt.Errorf("unknown kind: %s", params.Kind)
 	}
 
-	versions, err := c.getAPIVersionsForGR(ctx, params.Token, params.URL, params.Cluster, schema.GroupResource{
+	versions, err := c.getAPIVersionsForGR(ctx, params.Token, params.Cluster, schema.GroupResource{
 		Group:    currentGVK.Group,
 		Resource: currentGVK.Resource,
 	})
@@ -222,7 +237,7 @@ func (c *Client) GetResourcesAtAnyAPIVersion(ctx context.Context, params ListPar
 	var list *unstructured.UnstructuredList
 	for _, version := range versions {
 		currentGVK.Version = version
-		resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.URL, params.Namespace, params.Cluster, currentGVK)
+		resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.Namespace, params.Cluster, currentGVK)
 		if err != nil {
 			return nil, err
 		}
@@ -268,7 +283,7 @@ func (c *Client) GetResourcesAtAnyAPIVersion(ctx context.Context, params ListPar
 //  4. If not found, fall back to listing all clusters and matching by display name.
 //
 // both cluster ID and display name are cached for future lookups.
-func (c *Client) GetClusterID(ctx context.Context, token string, url string, clusterNameOrID string) (string, error) {
+func (c *Client) GetClusterID(ctx context.Context, token string, clusterNameOrID string) (string, error) {
 	// handle the special case for the local cluster, it always exists and is known by ID and displayName "local"
 	if clusterNameOrID == "local" {
 		return "local", nil
@@ -285,7 +300,7 @@ func (c *Client) GetClusterID(ctx context.Context, token string, url string, clu
 	}
 
 	// try to fetch the cluster directly by its ID
-	clusterInterface, err := c.GetResourceInterface(ctx, token, url, "", "local", converter.K8sKindsToGVRs["managementcluster"])
+	clusterInterface, err := c.GetResourceInterface(ctx, token, "", "local", converter.K8sKindsToGVRs["managementcluster"])
 	if err != nil {
 		return "", err
 	}
@@ -348,8 +363,8 @@ func (c *Client) GetClusterID(ctx context.Context, token string, url string, clu
 
 // CreateRestConfig creates a new rest.Config for accessing a Kubernetes cluster through Rancher.
 // It configures the cluster URL, authentication token, and TLS settings based on environment variables.
-func (c *Client) CreateRestConfig(token string, url string, clusterID string) (*rest.Config, error) {
-	clusterURL := url + "/k8s/clusters/" + clusterID
+func (c *Client) CreateRestConfig(token string, clusterID string) (*rest.Config, error) {
+	clusterURL := c.rancherURL + "/k8s/clusters/" + clusterID
 	kubeconfig := clientcmdapi.NewConfig()
 	kubeconfig.Clusters["Cluster"] = &clientcmdapi.Cluster{
 		Server:                clusterURL,
@@ -378,12 +393,12 @@ func (c *Client) CreateRestConfig(token string, url string, clusterID string) (*
 
 // getAPIVersionsForGR queries the API server for all supported versions of the specified GroupResource.
 // It returns a slice of version strings or an error if the query fails.
-func (c *Client) getAPIVersionsForGR(ctx context.Context, token, url, cluster string, groupResource schema.GroupResource) ([]string, error) {
-	clusterID, err := c.GetClusterID(ctx, token, url, cluster)
+func (c *Client) getAPIVersionsForGR(ctx context.Context, token, cluster string, groupResource schema.GroupResource) ([]string, error) {
+	clusterID, err := c.GetClusterID(ctx, token, cluster)
 	if err != nil {
 		return nil, err
 	}
-	restConfig, err := c.CreateRestConfig(token, url, clusterID)
+	restConfig, err := c.CreateRestConfig(token, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -405,4 +420,20 @@ func (c *Client) getAPIVersionsForGR(ctx context.Context, token, url, cluster st
 		}
 	}
 	return versions, nil
+}
+
+func rancherURLFromAuthServerURL(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	parsed.Path = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	return parsed.String(), nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -58,9 +58,6 @@ func NewClient(insecure bool, authzServerURL string) (*Client, error) {
 	}
 	if rancherURL == "" {
 		rancherURL = "https://rancher.cattle-system"
-		if insecure {
-			rancherURL = "http://rancher.cattle-system"
-		}
 	}
 	return &Client{
 		insecure:   insecure,

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -126,7 +126,7 @@ func TestGetClusterId(t *testing.T) {
 				},
 			}
 
-			clusterID, err := c.GetClusterID(context.TODO(), fakeToken, fakeUrl, test.clusterNameOrIDInput)
+			clusterID, err := c.GetClusterID(context.TODO(), fakeToken, test.clusterNameOrIDInput)
 
 			if test.expectErr != "" {
 				require.ErrorContains(t, err, test.expectErr)
@@ -184,7 +184,6 @@ func TestGetResource(t *testing.T) {
 				Kind:      "pod",
 				Namespace: "default",
 				Name:      "test-pod",
-				URL:       fakeUrl,
 				Token:     fakeToken,
 			},
 			fakeDynClient: dynamicfake.NewSimpleDynamicClient(scheme(), fakePod),
@@ -196,7 +195,6 @@ func TestGetResource(t *testing.T) {
 				Kind:      "pod",
 				Namespace: "default",
 				Name:      "nonexistent-pod",
-				URL:       fakeUrl,
 				Token:     fakeToken,
 			},
 			fakeDynClient: dynamicfake.NewSimpleDynamicClient(scheme()),
@@ -269,7 +267,6 @@ func TestGetResources(t *testing.T) {
 				Cluster:   "local",
 				Kind:      "pod",
 				Namespace: "default",
-				URL:       fakeUrl,
 				Token:     fakeToken,
 			},
 			fakeDynClient: dynamicfake.NewSimpleDynamicClient(scheme(), fakePod1, fakePod2, fakePod3),
@@ -281,7 +278,6 @@ func TestGetResources(t *testing.T) {
 				Cluster:       "local",
 				Kind:          "pod",
 				Namespace:     "default",
-				URL:           fakeUrl,
 				Token:         fakeToken,
 				LabelSelector: "app=nginx",
 			},
@@ -294,7 +290,6 @@ func TestGetResources(t *testing.T) {
 				Cluster:   "local",
 				Kind:      "pod",
 				Namespace: "kube-system",
-				URL:       fakeUrl,
 				Token:     fakeToken,
 			},
 			fakeDynClient: dynamicfake.NewSimpleDynamicClient(scheme()),
@@ -326,6 +321,53 @@ func TestGetResources(t *testing.T) {
 				}
 				assert.ElementsMatch(t, test.expectedNames, actualNames)
 			}
+		})
+	}
+}
+
+func TestRancherURLFromAuthServerURL(t *testing.T) {
+	testCases := map[string]struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		"empty input returns empty string": {
+			input:    "",
+			expected: "",
+			wantErr:  false,
+		},
+		"removes path query and fragment": {
+			input:    "https://rancher.example.com/v3-public/auth?scope=openid#section",
+			expected: "https://rancher.example.com",
+			wantErr:  false,
+		},
+		"keeps scheme host and port": {
+			input:    "https://rancher.example.com:9443/oauth2/authorize",
+			expected: "https://rancher.example.com:9443",
+			wantErr:  false,
+		},
+		"strips trailing slash-only path": {
+			input:    "https://rancher.example.com/",
+			expected: "https://rancher.example.com",
+			wantErr:  false,
+		},
+		"invalid URL returns error": {
+			input:   "http://[::1",
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual, err := rancherURLFromAuthServerURL(tt.input)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/client/test/wrapper.go
+++ b/pkg/client/test/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,6 +27,12 @@ func WrapClient(c *client.Client, expectedToken string) *clientWrapper {
 		client:        c,
 		expectedToken: expectedToken,
 	}
+}
+
+// NewCallToolRequest creates a new empty *mcp.CallToolRequest.
+// The url parameter is accepted for backward compatibility but is ignored.
+func NewCallToolRequest(_ string) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{}
 }
 
 // validateToken checks if the provided token matches the expected token.

--- a/pkg/client/test/wrapper.go
+++ b/pkg/client/test/wrapper.go
@@ -2,36 +2,29 @@ package test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
-
-const urlHeader string = "R_url"
 
 // clientWrapper wraps a *client.Client and validates tokens before delegating to the wrapped client.
 type clientWrapper struct {
-	client             *client.Client
-	expectedToken      string
-	expectedRequestURL string
+	client        *client.Client
+	expectedToken string
 }
 
-// WrapClient creates a new fake tools client that validates the token and
-// Rancher URL.
+// WrapClient creates a new fake tools client that validates the token.
 //
 // If expectedToken is empty, token validation is skipped.
-// If expectedURL is empty, expectedURL validation is skipped.
-func WrapClient(c *client.Client, expectedToken, expectedURL string) *clientWrapper {
+func WrapClient(c *client.Client, expectedToken string) *clientWrapper {
 	return &clientWrapper{
-		client:             c,
-		expectedToken:      expectedToken,
-		expectedRequestURL: expectedURL,
+		client:        c,
+		expectedToken: expectedToken,
 	}
 }
 
@@ -44,17 +37,12 @@ func (f *clientWrapper) validateToken(token string) error {
 	return nil
 }
 
-// validateRequestURL checks if the provided URL matches the expected URL.
-func (f *clientWrapper) validateRequestURL(requestURL string) error {
-	if f.expectedRequestURL == requestURL {
-		return nil
-	}
+func (f *clientWrapper) RancherURL() string {
+	return f.client.RancherURL()
+}
 
-	if requestURL == "" {
-		return errors.New("no URL for rancher request")
-	}
-
-	return fmt.Errorf("invalid requestURL: expected %q, got %q", f.expectedRequestURL, requestURL)
+func (f *clientWrapper) CreateRestConfig(token string, clusterID string) (*rest.Config, error) {
+	return f.client.CreateRestConfig(token, clusterID)
 }
 
 // GetResource validates the token and delegates to the wrapped client.
@@ -62,23 +50,17 @@ func (f *clientWrapper) GetResource(ctx context.Context, params client.GetParams
 	if err := f.validateToken(params.Token); err != nil {
 		return nil, err
 	}
-	if err := f.validateRequestURL(params.URL); err != nil {
-		return nil, err
-	}
 
 	return f.client.GetResource(ctx, params)
 }
 
 // GetResourceInterface validates the token and delegates to the wrapped client.
-func (f *clientWrapper) GetResourceInterface(ctx context.Context, token string, url string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
+func (f *clientWrapper) GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
 	if err := f.validateToken(token); err != nil {
 		return nil, err
 	}
-	if err := f.validateRequestURL(url); err != nil {
-		return nil, err
-	}
 
-	return f.client.GetResourceInterface(ctx, token, url, namespace, cluster, gvr)
+	return f.client.GetResourceInterface(ctx, token, namespace, cluster, gvr)
 }
 
 // GetResources validates the token and delegates to the wrapped client.
@@ -86,30 +68,21 @@ func (f *clientWrapper) GetResources(ctx context.Context, params client.ListPara
 	if err := f.validateToken(params.Token); err != nil {
 		return nil, err
 	}
-	if err := f.validateRequestURL(params.URL); err != nil {
-		return nil, err
-	}
 
 	return f.client.GetResources(ctx, params)
 }
 
 // CreateClientSet validates the token and delegates to the wrapped client.
-func (f *clientWrapper) CreateClientSet(ctx context.Context, token string, url string, cluster string) (kubernetes.Interface, error) {
+func (f *clientWrapper) CreateClientSet(ctx context.Context, token string, cluster string) (kubernetes.Interface, error) {
 	if err := f.validateToken(token); err != nil {
 		return nil, err
 	}
-	if err := f.validateRequestURL(url); err != nil {
-		return nil, err
-	}
 
-	return f.client.CreateClientSet(ctx, token, url, cluster)
+	return f.client.CreateClientSet(ctx, token, cluster)
 }
 
 func (f *clientWrapper) GetResourceAtAnyAPIVersion(ctx context.Context, params client.GetParams) (*unstructured.Unstructured, error) {
 	if err := f.validateToken(params.Token); err != nil {
-		return nil, err
-	}
-	if err := f.validateRequestURL(params.URL); err != nil {
 		return nil, err
 	}
 
@@ -120,9 +93,6 @@ func (f *clientWrapper) GetResourceByGVR(ctx context.Context, params client.GetP
 	if err := f.validateToken(params.Token); err != nil {
 		return nil, err
 	}
-	if err := f.validateRequestURL(params.URL); err != nil {
-		return nil, err
-	}
 
 	return f.client.GetResourceByGVR(ctx, params, gvr)
 }
@@ -131,32 +101,14 @@ func (f *clientWrapper) GetResourcesAtAnyAPIVersion(ctx context.Context, params 
 	if err := f.validateToken(params.Token); err != nil {
 		return nil, err
 	}
-	if err := f.validateRequestURL(params.URL); err != nil {
-		return nil, err
-	}
 
 	return f.client.GetResourcesAtAnyAPIVersion(ctx, params)
 }
 
-func (f *clientWrapper) GetClusterID(ctx context.Context, token string, url string, clusterNameOrID string) (string, error) {
+func (f *clientWrapper) GetClusterID(ctx context.Context, token string, clusterNameOrID string) (string, error) {
 	if err := f.validateToken(token); err != nil {
 		return "", err
 	}
-	if err := f.validateRequestURL(url); err != nil {
-		return "", err
-	}
 
-	return f.client.GetClusterID(ctx, token, url, clusterNameOrID)
-}
-
-// NewCallToolRequest creates and returns a CallToolRequest.
-//
-// The R_url header will be set to the requestURL if requestURL is not empty.
-func NewCallToolRequest(requestURL string) *mcp.CallToolRequest {
-	req := &mcp.CallToolRequest{Extra: &mcp.RequestExtra{Header: map[string][]string{}}}
-	if requestURL != "" {
-		req.Extra.Header[urlHeader] = []string{requestURL}
-	}
-
-	return req
+	return f.client.GetClusterID(ctx, token, clusterNameOrID)
 }

--- a/pkg/toolsets/core/create_project.go
+++ b/pkg/toolsets/core/create_project.go
@@ -28,7 +28,7 @@ func (t *Tools) createProject(ctx context.Context, toolReq *mcp.CallToolRequest,
 	zap.L().Debug("createProject called", zap.String("cluster", params.Cluster))
 
 	resourceInterface, err := t.client.GetResourceInterface(
-		ctx, middleware.Token(ctx), t.rancherURL(toolReq),
+		ctx, middleware.Token(ctx),
 		params.Cluster, "local", converter.K8sKindsToGVRs["project"])
 	if err != nil {
 		return nil, nil, err

--- a/pkg/toolsets/core/create_project_plan_test.go
+++ b/pkg/toolsets/core/create_project_plan_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestCreateProjectPlan(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	tests := map[string]struct {
@@ -123,8 +122,8 @@ func TestCreateProjectPlan(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &client.Client{}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), "", false)
-			req := test.NewCallToolRequest(fakeUrl)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.createProjectPlan(context.Background(), req, tt.params)
 

--- a/pkg/toolsets/core/create_project_test.go
+++ b/pkg/toolsets/core/create_project_test.go
@@ -129,16 +129,6 @@ func TestCreateProject(t *testing.T) {
 				]
 			}`,
 		},
-		"create project - no rancherURL or request URL": {
-			// fails because requestURL and rancherURL are not configured (no
-			// R_Url or configured Rancher URL.
-			params: createProjectParams{
-				Cluster: "local",
-				Name:    "error-project",
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClient(createProjectScheme()),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -148,8 +138,8 @@ func TestCreateProject(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.createProject(middleware.WithToken(t.Context(), fakeToken), req, tt.params)
 

--- a/pkg/toolsets/core/create_resource.go
+++ b/pkg/toolsets/core/create_resource.go
@@ -15,10 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const (
-	urlHeader = "R_url"
-)
-
 // createKubernetesResourceParams defines the structure for creating a general Kubernetes resource.
 type createKubernetesResourceParams struct {
 	Name      string `json:"name" jsonschema:"the name of the resource to create"`
@@ -33,7 +29,7 @@ func (t *Tools) createKubernetesResource(ctx context.Context, toolReq *mcp.CallT
 	zap.L().Debug("createKubernetesResource called")
 
 	resourceInterface, err := t.client.GetResourceInterface(
-		ctx, middleware.Token(ctx), t.rancherURL(toolReq),
+		ctx, middleware.Token(ctx),
 		params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
 	if err != nil {
 		return nil, nil, err

--- a/pkg/toolsets/core/create_resource_test.go
+++ b/pkg/toolsets/core/create_resource_test.go
@@ -130,19 +130,6 @@ func TestCreateKubernetesResource(t *testing.T) {
 			}),
 			expectedError: "failed to create unstructured object",
 		},
-		"create configmap - no rancherURL or request URL": {
-			// fails because requestURL and rancherURL are not configured (no
-			// R_Url or configured Rancher URL.
-			params: createKubernetesResourceParams{
-				Name:      "test-config",
-				Namespace: "default",
-				Kind:      "configmap",
-				Cluster:   "local",
-				Resource:  make(chan int),
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClient(createResourceScheme()),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -152,8 +139,8 @@ func TestCreateKubernetesResource(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.createKubernetesResource(middleware.WithToken(t.Context(), fakeToken), req, tt.params)
 

--- a/pkg/toolsets/core/fake_client_test.go
+++ b/pkg/toolsets/core/fake_client_test.go
@@ -43,11 +43,11 @@ func (f *fakeToolsClient) GetResource(ctx context.Context, params client.GetPara
 }
 
 // GetResourceInterface validates the token and delegates to the wrapped client.
-func (f *fakeToolsClient) GetResourceInterface(ctx context.Context, token string, url string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
+func (f *fakeToolsClient) GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
 	if err := f.validateToken(token); err != nil {
 		return nil, err
 	}
-	return f.client.GetResourceInterface(ctx, token, url, namespace, cluster, gvr)
+	return f.client.GetResourceInterface(ctx, token, namespace, cluster, gvr)
 }
 
 // GetResources validates the token and delegates to the wrapped client.
@@ -59,16 +59,16 @@ func (f *fakeToolsClient) GetResources(ctx context.Context, params client.ListPa
 }
 
 // CreateClientSet validates the token and delegates to the wrapped client.
-func (f *fakeToolsClient) CreateClientSet(ctx context.Context, token string, url string, cluster string) (kubernetes.Interface, error) {
+func (f *fakeToolsClient) CreateClientSet(ctx context.Context, token string, cluster string) (kubernetes.Interface, error) {
 	if err := f.validateToken(token); err != nil {
 		return nil, err
 	}
-	return f.client.CreateClientSet(ctx, token, url, cluster)
+	return f.client.CreateClientSet(ctx, token, cluster)
 }
 
-func (f *fakeToolsClient) GetClusterID(ctx context.Context, token string, url string, clusterNameOrID string) (string, error) {
+func (f *fakeToolsClient) GetClusterID(ctx context.Context, token string, clusterNameOrID string) (string, error) {
 	if err := f.validateToken(token); err != nil {
 		return "", err
 	}
-	return f.client.GetClusterID(ctx, token, url, clusterNameOrID)
+	return f.client.GetClusterID(ctx, token, clusterNameOrID)
 }

--- a/pkg/toolsets/core/get_cluster_images.go
+++ b/pkg/toolsets/core/get_cluster_images.go
@@ -28,7 +28,6 @@ func (t *Tools) getClusterImages(ctx context.Context, toolReq *mcp.CallToolReque
 		clusterList, err := t.client.GetResources(ctx, client.ListParams{
 			Cluster: "local",
 			Kind:    "managementcluster",
-			URL:     t.rancherURL(toolReq),
 			Token:   middleware.Token(ctx),
 		})
 
@@ -50,7 +49,6 @@ func (t *Tools) getClusterImages(ctx context.Context, toolReq *mcp.CallToolReque
 		unstructuredPods, err := t.client.GetResources(ctx, client.ListParams{
 			Cluster: cluster,
 			Kind:    "pod",
-			URL:     t.rancherURL(toolReq),
 			Token:   middleware.Token(ctx),
 		})
 		if err != nil {

--- a/pkg/toolsets/core/get_cluster_images_test.go
+++ b/pkg/toolsets/core/get_cluster_images_test.go
@@ -94,15 +94,6 @@ func TestGetClusterImages(t *testing.T) {
 				"local": ["busybox:latest", "nginx:1.21", "redis:alpine"]
 			}`,
 		},
-		"get images from cluster - no rancherURL or request URL": {
-			// fails because requestURL and rancherURL are not configured (no
-			// R_Url or configured Rancher URL.
-			params: getClusterImagesParams{Clusters: []string{"local"}},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(podScheme(), map[schema.GroupVersionResource]string{
-				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
-			}, fakePodWithImage),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -113,8 +104,8 @@ func TestGetClusterImages(t *testing.T) {
 				},
 			}
 
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.getClusterImages(middleware.WithToken(t.Context(), fakeToken), req, tt.params)
 

--- a/pkg/toolsets/core/get_deployment.go
+++ b/pkg/toolsets/core/get_deployment.go
@@ -31,7 +31,6 @@ func (t *Tools) getDeploymentDetails(ctx context.Context, toolReq *mcp.CallToolR
 		Kind:      "deployment",
 		Namespace: params.Namespace,
 		Name:      params.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {
@@ -56,7 +55,6 @@ func (t *Tools) getDeploymentDetails(ctx context.Context, toolReq *mcp.CallToolR
 		Kind:          "pod",
 		Namespace:     params.Namespace,
 		Name:          params.Name,
-		URL:           t.rancherURL(toolReq),
 		Token:         middleware.Token(ctx),
 		LabelSelector: selector.String(),
 	})

--- a/pkg/toolsets/core/get_deployment_test.go
+++ b/pkg/toolsets/core/get_deployment_test.go
@@ -207,18 +207,6 @@ func TestGetDeploymentDetails(t *testing.T) {
 				]
 			}`,
 		},
-		"get deployment from cluster - no rancherURL or request URL": {
-			params: specificResourceParams{
-				Name:      "nonexistent-deployment",
-				Namespace: "default",
-				Cluster:   "local",
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(deploymentScheme(), map[schema.GroupVersionResource]string{
-				{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
-				{Group: "", Version: "v1", Resource: "pods"}:            "PodList",
-			}),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -228,7 +216,7 @@ func TestGetDeploymentDetails(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
 			req := test.NewCallToolRequest(tt.requestURL)
 
 			result, _, err := tools.getDeploymentDetails(middleware.WithToken(t.Context(), fakeToken), req, tt.params)

--- a/pkg/toolsets/core/get_nodes.go
+++ b/pkg/toolsets/core/get_nodes.go
@@ -22,7 +22,6 @@ func (t *Tools) getNodes(ctx context.Context, toolReq *mcp.CallToolRequest, para
 	nodeResource, err := t.client.GetResources(ctx, client.ListParams{
 		Cluster: params.Cluster,
 		Kind:    "node",
-		URL:     t.rancherURL(toolReq),
 		Token:   middleware.Token(ctx),
 	})
 	if err != nil {
@@ -34,7 +33,6 @@ func (t *Tools) getNodes(ctx context.Context, toolReq *mcp.CallToolRequest, para
 	nodeMetricsResource, _ := t.client.GetResources(ctx, client.ListParams{
 		Cluster: params.Cluster,
 		Kind:    "node.metrics.k8s.io",
-		URL:     t.rancherURL(toolReq),
 		Token:   middleware.Token(ctx),
 	})
 

--- a/pkg/toolsets/core/get_nodes_test.go
+++ b/pkg/toolsets/core/get_nodes_test.go
@@ -130,14 +130,6 @@ func TestGetNodes(t *testing.T) {
 			}),
 			expectedResult: `{"llm":"no resources found"}`,
 		},
-		"get nodes no rancherURL or request URL": {
-			params: getNodesParams{Cluster: "local"},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(nodeScheme(), map[schema.GroupVersionResource]string{
-				{Group: "", Version: "v1", Resource: "nodes"}:                    "NodeList",
-				{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "nodes"}: "NodeMetricsList",
-			}),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -147,7 +139,7 @@ func TestGetNodes(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
 			req := test.NewCallToolRequest(tt.requestURL)
 
 			result, _, err := tools.getNodes(middleware.WithToken(t.Context(), fakeToken), req, tt.params)

--- a/pkg/toolsets/core/get_project.go
+++ b/pkg/toolsets/core/get_project.go
@@ -23,13 +23,12 @@ type getProjectParams struct {
 }
 
 // getProjectID retrieves the project ID for a given project name.
-func (t *Tools) getProjectID(ctx context.Context, token, url, clusterID, projectNameOrID string) (string, *unstructured.Unstructured, error) {
+func (t *Tools) getProjectID(ctx context.Context, token, clusterID, projectNameOrID string) (string, *unstructured.Unstructured, error) {
 	projectResource, err := t.client.GetResource(ctx, client.GetParams{
 		Cluster:   LocalCluster,
 		Kind:      "project",
 		Namespace: clusterID,
 		Name:      projectNameOrID,
-		URL:       url,
 		Token:     token,
 	})
 	if err == nil {
@@ -44,7 +43,6 @@ func (t *Tools) getProjectID(ctx context.Context, token, url, clusterID, project
 		Cluster:   LocalCluster,
 		Kind:      "project",
 		Namespace: clusterID,
-		URL:       url,
 		Token:     token,
 	})
 	if err != nil {
@@ -69,13 +67,13 @@ func (t *Tools) getProjectID(ctx context.Context, token, url, clusterID, project
 func (t *Tools) getProject(ctx context.Context, toolReq *mcp.CallToolRequest, params getProjectParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("getProject called")
 
-	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Cluster)
+	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
 	if err != nil {
 		zap.L().Error("failed to get cluster ID", zapGetProject, zap.Error(err))
 		return nil, nil, err
 	}
 
-	projectID, projectResource, err := t.getProjectID(ctx, middleware.Token(ctx), t.rancherURL(toolReq), clusterID, params.Name)
+	projectID, projectResource, err := t.getProjectID(ctx, middleware.Token(ctx), clusterID, params.Name)
 	if err != nil {
 		zap.L().Error("failed to get project", zapGetProject, zap.Error(err))
 		return nil, nil, err
@@ -95,7 +93,6 @@ func (t *Tools) getProject(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 		Cluster:       clusterID,
 		Kind:          "namespace",
 		LabelSelector: projectLabel.String(),
-		URL:           t.rancherURL(toolReq),
 		Token:         middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/core/get_project_resource_usage.go
+++ b/pkg/toolsets/core/get_project_resource_usage.go
@@ -50,7 +50,7 @@ func newSample() sample {
 func (t *Tools) getResourceUsage(ctx context.Context, toolReq *mcp.CallToolRequest, params getResourceUsageParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("getResourceUsage called")
 
-	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Cluster)
+	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
 	if err != nil {
 		zap.L().Error("failed to get cluster ID", zapGetResourceUsage, zap.Error(err))
 		return nil, nil, err
@@ -67,7 +67,6 @@ func (t *Tools) getResourceUsage(ctx context.Context, toolReq *mcp.CallToolReque
 			Cluster: clusterID,
 			Kind:    "namespace",
 			Name:    params.Namespace,
-			URL:     t.rancherURL(toolReq),
 			Token:   middleware.Token(ctx),
 		})
 		if err != nil {
@@ -85,7 +84,7 @@ func (t *Tools) getResourceUsage(ctx context.Context, toolReq *mcp.CallToolReque
 	} else {
 		var projectResources []*unstructured.Unstructured
 		if params.Project != "" {
-			_, projectResource, err := t.getProjectID(ctx, middleware.Token(ctx), t.rancherURL(toolReq), clusterID, params.Project)
+			_, projectResource, err := t.getProjectID(ctx, middleware.Token(ctx), clusterID, params.Project)
 			if err != nil {
 				zap.L().Error("failed to get project", zapGetResourceUsage, zap.Error(err))
 				return nil, nil, err
@@ -97,7 +96,6 @@ func (t *Tools) getResourceUsage(ctx context.Context, toolReq *mcp.CallToolReque
 				Cluster:   LocalCluster,
 				Kind:      "project",
 				Namespace: clusterID,
-				URL:       t.rancherURL(toolReq),
 				Token:     middleware.Token(ctx),
 			})
 			if err != nil {
@@ -128,7 +126,6 @@ func (t *Tools) getResourceUsage(ctx context.Context, toolReq *mcp.CallToolReque
 				Cluster:       clusterID,
 				Kind:          "namespace",
 				LabelSelector: projectLabel.String(),
-				URL:           t.rancherURL(toolReq),
 				Token:         middleware.Token(ctx),
 			})
 			if err != nil {
@@ -205,7 +202,6 @@ func (t *Tools) getNamespaceResourceUsage(ctx context.Context, toolReq *mcp.Call
 		Cluster:   clusterID,
 		Kind:      "pod",
 		Namespace: namespace,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {
@@ -217,7 +213,6 @@ func (t *Tools) getNamespaceResourceUsage(ctx context.Context, toolReq *mcp.Call
 		Cluster:   clusterID,
 		Kind:      "pod.metrics.k8s.io",
 		Namespace: namespace,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/core/get_project_resource_usage_test.go
+++ b/pkg/toolsets/core/get_project_resource_usage_test.go
@@ -54,7 +54,7 @@ func newProjectResourceUsageTools(t *testing.T, fakeToken, fakeURL, rancherURL s
 			return fakeDynClient, nil
 		},
 	}
-	return NewTools(test.WrapClient(c, fakeToken, fakeURL), rancherURL, false)
+	return NewTools(test.WrapClient(c, fakeToken), false)
 }
 
 func TestGetResourceUsage(t *testing.T) {

--- a/pkg/toolsets/core/get_project_test.go
+++ b/pkg/toolsets/core/get_project_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestGetProject(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	cluster := &unstructured.Unstructured{
@@ -93,9 +92,7 @@ func TestGetProject(t *testing.T) {
 		}
 		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
 
-		result, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-			Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-		}, getProjectParams{
+		result, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, getProjectParams{
 			Name:    "my-project",
 			Cluster: "test-cluster",
 		})
@@ -181,9 +178,7 @@ func TestGetProject(t *testing.T) {
 		}
 		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
 
-		_, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-			Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-		}, getProjectParams{
+		_, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, getProjectParams{
 			Name:    "nonexistent-project",
 			Cluster: "test-cluster",
 		})
@@ -201,9 +196,7 @@ func TestGetProject(t *testing.T) {
 		}
 		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
 
-		result, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-			Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-		}, getProjectParams{
+		result, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, getProjectParams{
 			Name:    "my-project",
 			Cluster: "test-cluster",
 		})

--- a/pkg/toolsets/core/get_resource.go
+++ b/pkg/toolsets/core/get_resource.go
@@ -28,7 +28,6 @@ func (t *Tools) getResource(ctx context.Context, toolReq *mcp.CallToolRequest, p
 		Kind:      params.Kind,
 		Namespace: params.Namespace,
 		Name:      params.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/core/get_resource_test.go
+++ b/pkg/toolsets/core/get_resource_test.go
@@ -70,11 +70,6 @@ func TestGetResource(t *testing.T) {
 			requestURL:    fakeUrl,
 			expectedError: `pods "rancher" not found`,
 		},
-		"get pod no rancherURL or request URL": {
-			params:        resourceParams{Name: "rancher", Kind: "pod", Namespace: "default", Cluster: "local"},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClient(scheme()),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -85,7 +80,7 @@ func TestGetResource(t *testing.T) {
 				},
 			}
 
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
 			req := test.NewCallToolRequest(tt.requestURL)
 
 			result, _, err := tools.getResource(middleware.WithToken(t.Context(), fakeToken), req, tt.params)

--- a/pkg/toolsets/core/inspect_pod.go
+++ b/pkg/toolsets/core/inspect_pod.go
@@ -36,7 +36,6 @@ func (t *Tools) inspectPod(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 		Kind:      "pod",
 		Namespace: params.Namespace,
 		Name:      params.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {
@@ -68,7 +67,6 @@ func (t *Tools) inspectPod(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 			Kind:      "replicaset",
 			Namespace: params.Namespace,
 			Name:      replicaSetName,
-			URL:       t.rancherURL(toolReq),
 			Token:     middleware.Token(ctx),
 		})
 		if err != nil {
@@ -98,7 +96,6 @@ func (t *Tools) inspectPod(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 				Kind:      parentKind,
 				Namespace: params.Namespace,
 				Name:      parentName,
-				URL:       t.rancherURL(toolReq),
 				Token:     middleware.Token(ctx),
 			})
 			if err != nil {
@@ -114,11 +111,10 @@ func (t *Tools) inspectPod(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 		Kind:      "pod.metrics.k8s.io",
 		Namespace: params.Namespace,
 		Name:      params.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 
-	logs, err := t.getPodLogs(ctx, t.rancherURL(toolReq), params.Cluster, middleware.Token(ctx), pod)
+	logs, err := t.getPodLogs(ctx, params.Cluster, middleware.Token(ctx), pod)
 	if err != nil {
 		zap.L().Error("failed to get pod logs", zap.String("tool", "inspectPod"), zap.Error(err))
 		return nil, nil, err
@@ -146,8 +142,8 @@ func (t *Tools) inspectPod(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 // getPodLogs retrieves the logs for all containers in a pod.
 // It returns the logs as an unstructured object with container names as keys.
 // Only the last 50 lines of logs are retrieved per container to limit payload size.
-func (t *Tools) getPodLogs(ctx context.Context, url string, cluster string, token string, pod corev1.Pod) (*unstructured.Unstructured, error) {
-	clientset, err := t.client.CreateClientSet(ctx, token, url, cluster)
+func (t *Tools) getPodLogs(ctx context.Context, cluster string, token string, pod corev1.Pod) (*unstructured.Unstructured, error) {
+	clientset, err := t.client.CreateClientSet(ctx, token, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clientset: %w", err)
 	}

--- a/pkg/toolsets/core/inspect_pod_test.go
+++ b/pkg/toolsets/core/inspect_pod_test.go
@@ -621,16 +621,6 @@ func TestInspectPod(t *testing.T) {
 				]
 			}`,
 		},
-		"inspect pod - no rancherURL or request URL": {
-			params: specificResourceParams{
-				Name:      "nonexistent-pod",
-				Namespace: "default",
-				Cluster:   "local",
-			},
-			fakeClientset: fake.NewSimpleClientset(),
-			fakeDynClient: dynamicfake.NewSimpleDynamicClient(inspectPodScheme()),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -643,7 +633,7 @@ func TestInspectPod(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
 			req := test.NewCallToolRequest(tt.requestURL)
 
 			result, _, err := tools.inspectPod(middleware.WithToken(t.Context(), fakeToken), req, tt.params)

--- a/pkg/toolsets/core/list_clusters.go
+++ b/pkg/toolsets/core/list_clusters.go
@@ -20,7 +20,6 @@ func (t *Tools) listClusters(ctx context.Context, toolReq *mcp.CallToolRequest, 
 	resources, err := t.client.GetResources(ctx, client.ListParams{
 		Cluster: LocalCluster,
 		Kind:    converter.ManagementClusterResourceKind,
-		URL:     t.rancherURL(toolReq),
 		Token:   middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/core/list_clusters_test.go
+++ b/pkg/toolsets/core/list_clusters_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestListClusters(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	scheme := runtime.NewScheme()
@@ -60,9 +59,7 @@ func TestListClusters(t *testing.T) {
 		}
 		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
 
-		result, _, err := tools.listClusters(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-			Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-		}, struct{}{})
+		result, _, err := tools.listClusters(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, struct{}{})
 
 		require.NoError(t, err)
 		assert.NotNil(t, result)

--- a/pkg/toolsets/core/list_projects.go
+++ b/pkg/toolsets/core/list_projects.go
@@ -20,7 +20,7 @@ type listProjectsParams struct {
 func (t *Tools) listProjects(ctx context.Context, toolReq *mcp.CallToolRequest, params listProjectsParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("listProjects called")
 
-	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Cluster)
+	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
 	if err != nil {
 		zap.L().Error("failed to get cluster ID", zapListProjects, zap.Error(err))
 		return nil, nil, err
@@ -30,7 +30,6 @@ func (t *Tools) listProjects(ctx context.Context, toolReq *mcp.CallToolRequest, 
 		Cluster:   LocalCluster,
 		Kind:      "project",
 		Namespace: clusterID,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/core/list_projects_test.go
+++ b/pkg/toolsets/core/list_projects_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestListProjects(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	cluster := &unstructured.Unstructured{
@@ -82,9 +81,7 @@ func TestListProjects(t *testing.T) {
 		}
 		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
 
-		result, _, err := tools.listProjects(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-			Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-		}, listProjectsParams{
+		result, _, err := tools.listProjects(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, listProjectsParams{
 			Cluster: "test-cluster",
 		})
 

--- a/pkg/toolsets/core/list_resources.go
+++ b/pkg/toolsets/core/list_resources.go
@@ -35,7 +35,6 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 		Cluster:       params.Cluster,
 		Kind:          params.Kind,
 		Namespace:     params.Namespace,
-		URL:           t.rancherURL(toolReq),
 		Token:         middleware.Token(ctx),
 		LabelSelector: params.LabelSelector,
 	})

--- a/pkg/toolsets/core/list_resources_test.go
+++ b/pkg/toolsets/core/list_resources_test.go
@@ -136,17 +136,6 @@ func TestListKubernetesResources(t *testing.T) {
 				]
 			}`,
 		},
-		"list pods - no rancherURL or request URL": {
-			params: listKubernetesResourcesParams{
-				Kind:      "pod",
-				Namespace: "kube-system",
-				Cluster:   "local",
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
-				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
-			}),
-			expectedError: "no URL for rancher request",
-		},
 		"list pods - with explicit limit": {
 			params: listKubernetesResourcesParams{
 				Kind:      "pod",
@@ -180,7 +169,7 @@ func TestListKubernetesResources(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
 			req := test.NewCallToolRequest(tt.requestURL)
 
 			result, _, err := tools.listKubernetesResources(middleware.WithToken(t.Context(), fakeToken), req, tt.params)

--- a/pkg/toolsets/core/patch_resource.go
+++ b/pkg/toolsets/core/patch_resource.go
@@ -38,7 +38,7 @@ type updateKubernetesResourceParams struct {
 func (t *Tools) updateKubernetesResource(ctx context.Context, toolReq *mcp.CallToolRequest, params updateKubernetesResourceParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("updateKubernetesResource called")
 
-	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
+	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/toolsets/core/patch_resource_plan.go
+++ b/pkg/toolsets/core/patch_resource_plan.go
@@ -20,7 +20,7 @@ import (
 func (t *Tools) updateKubernetesResourcePlan(ctx context.Context, toolReq *mcp.CallToolRequest, params updateKubernetesResourceParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("updateKubernetesResource_plan called")
 
-	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
+	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/toolsets/core/patch_resource_plan_test.go
+++ b/pkg/toolsets/core/patch_resource_plan_test.go
@@ -247,7 +247,7 @@ func TestUpdateKubernetesResourcePlan(t *testing.T) {
 				},
 			}
 
-			tools := NewTools(test.WrapClient(c, "test-token", "https://localhost:8080"), "", false)
+			tools := NewTools(test.WrapClient(c, "test-token"), false)
 			req := test.NewCallToolRequest("https://localhost:8080")
 			ctx := middleware.WithToken(t.Context(), "test-token")
 

--- a/pkg/toolsets/core/patch_resource_test.go
+++ b/pkg/toolsets/core/patch_resource_test.go
@@ -196,25 +196,6 @@ func TestUpdateKubernetesResource(t *testing.T) {
 			requestURL:    fakeUrl,
 			expectedError: `configmaps "nonexistent-config" not found`,
 		},
-		"update configmap - no rancherURL or request URL": {
-			params: updateKubernetesResourceParams{
-				Name:      "nonexistent-config",
-				Namespace: "default",
-				Kind:      "configmap",
-				Cluster:   "local",
-				Patch: []jsonPatch{
-					{
-						Op:    "replace",
-						Path:  "/data/key1",
-						Value: "value",
-					},
-				},
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(patchResourceScheme(), map[schema.GroupVersionResource]string{
-				{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
-			}),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -224,7 +205,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
 			req := test.NewCallToolRequest(tt.requestURL)
 
 			result, _, err := tools.updateKubernetesResource(middleware.WithToken(t.Context(), fakeToken), req, tt.params)

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -18,34 +18,24 @@ const (
 
 type toolsClient interface {
 	GetResource(ctx context.Context, params client.GetParams) (*unstructured.Unstructured, error)
-	GetResourceInterface(ctx context.Context, token string, url string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error)
+	GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error)
 	GetResources(ctx context.Context, params client.ListParams) ([]*unstructured.Unstructured, error)
-	CreateClientSet(ctx context.Context, token string, url string, cluster string) (kubernetes.Interface, error)
-	GetClusterID(ctx context.Context, token string, url string, clusterNameOrID string) (string, error)
+	CreateClientSet(ctx context.Context, token string, cluster string) (kubernetes.Interface, error)
+	GetClusterID(ctx context.Context, token string, clusterNameOrID string) (string, error)
 }
 
 // Tools contains all tools for the MCP server
 type Tools struct {
-	client     toolsClient
-	RancherURL string
-	ReadOnly   bool
+	client   toolsClient
+	ReadOnly bool
 }
 
 // NewTools creates and returns a new Tools instance.
-func NewTools(client toolsClient, rancherURL string, readOnly bool) *Tools {
+func NewTools(client toolsClient, readOnly bool) *Tools {
 	return &Tools{
-		client:     client,
-		RancherURL: rancherURL,
-		ReadOnly:   readOnly,
+		client:   client,
+		ReadOnly: readOnly,
 	}
-}
-
-func (t *Tools) rancherURL(toolReq *mcp.CallToolRequest) string {
-	if t.RancherURL == "" {
-		return toolReq.Extra.Header.Get(urlHeader)
-	}
-
-	return t.RancherURL
 }
 
 // AddTools registers all Rancher Kubernetes tools with the provided MCP server.

--- a/pkg/toolsets/core/tools_test.go
+++ b/pkg/toolsets/core/tools_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestAddTools(t *testing.T) {
-	tools := NewTools(client.NewClient(true), "not-used-in-test", false)
+	c, _ := client.NewClient(true, "")
+	tools := NewTools(c, false)
 
 	// Create a test MCP server
 	mcpServer := mcp.NewServer(&mcp.Implementation{
@@ -69,7 +70,8 @@ func TestAddTools(t *testing.T) {
 }
 
 func TestAddToolsReadOnly(t *testing.T) {
-	tools := NewTools(client.NewClient(true), "not-used-in-test", true)
+	c, _ := client.NewClient(true, "")
+	tools := NewTools(c, true)
 
 	mcpServer := mcp.NewServer(&mcp.Implementation{
 		Name:    "test-server",

--- a/pkg/toolsets/fleet/analyse.go
+++ b/pkg/toolsets/fleet/analyse.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
-	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"go.uber.org/zap"
 )
 
@@ -17,8 +16,7 @@ type analyzeFleetResourcesParams struct {
 func (t *Tools) analyzeFleetResources(ctx context.Context, toolReq *mcp.CallToolRequest, params analyzeFleetResourcesParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("analyzeFleetResources called")
 
-	c := client.Client{}
-	restCfg, err := c.CreateRestConfig(middleware.Token(ctx), t.rancherURL(toolReq), "local")
+	restCfg, err := t.client.CreateRestConfig(middleware.Token(ctx), "local")
 	if err != nil {
 		zap.L().Error("failed to create rest config", zap.Error(err))
 		return nil, nil, fmt.Errorf("failed to create rest config: %w", err)

--- a/pkg/toolsets/fleet/analyse_test.go
+++ b/pkg/toolsets/fleet/analyse_test.go
@@ -7,10 +7,27 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 )
+
+// fakeFleetClient is a minimal toolsClient implementation for tests.
+type fakeFleetClient struct{}
+
+func (f *fakeFleetClient) GetResource(_ context.Context, _ client.GetParams) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (f *fakeFleetClient) GetResources(_ context.Context, _ client.ListParams) ([]*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (f *fakeFleetClient) CreateRestConfig(_ string, _ string) (*rest.Config, error) {
+	return &rest.Config{}, nil
+}
 
 // fakeResourceAnalyzer is a test double for the resourceAnalyzer interface.
 type fakeResourceAnalyzer struct {
@@ -44,6 +61,7 @@ func TestAnalyzeFleetResources(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tools := &Tools{
 				resourceAnalyzer: tt.analyzer,
+				client:           &fakeFleetClient{},
 			}
 			req := &mcp.CallToolRequest{}
 

--- a/pkg/toolsets/fleet/analyse_test.go
+++ b/pkg/toolsets/fleet/analyse_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
-	"github.com/rancher/rancher-ai-mcp/pkg/client/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
@@ -24,29 +23,19 @@ func (f *fakeResourceAnalyzer) analyzeFleetResources(_ context.Context, _ *rest.
 }
 
 func TestAnalyzeFleetResources(t *testing.T) {
-	fakeURL := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	tests := map[string]struct {
 		analyzer       *fakeResourceAnalyzer
-		requestURL     string
-		rancherURL     string
 		expectedResult string
 		expectedError  string
 	}{
-		"returns report on success using request URL": {
+		"returns report on success": {
 			analyzer:       &fakeResourceAnalyzer{report: "fleet is healthy"},
-			requestURL:     fakeURL,
 			expectedResult: "fleet is healthy",
-		},
-		"returns report on success using configured rancherURL": {
-			analyzer:       &fakeResourceAnalyzer{report: "2 bundles not ready"},
-			rancherURL:     fakeURL,
-			expectedResult: "2 bundles not ready",
 		},
 		"error from resourceAnalyzer is propagated": {
 			analyzer:      &fakeResourceAnalyzer{err: errors.New("cluster unreachable")},
-			requestURL:    fakeURL,
 			expectedError: "cluster unreachable",
 		},
 	}
@@ -54,10 +43,9 @@ func TestAnalyzeFleetResources(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			tools := &Tools{
-				RancherURL:       tt.rancherURL,
 				resourceAnalyzer: tt.analyzer,
 			}
-			req := test.NewCallToolRequest(tt.requestURL)
+			req := &mcp.CallToolRequest{}
 
 			result, extra, err := tools.analyzeFleetResources(
 				middleware.WithToken(t.Context(), fakeToken),

--- a/pkg/toolsets/fleet/get_bundle.go
+++ b/pkg/toolsets/fleet/get_bundle.go
@@ -28,7 +28,6 @@ func (t *Tools) getBundle(ctx context.Context, toolReq *mcp.CallToolRequest, par
 		Kind:      "bundle",
 		Namespace: params.Workspace,
 		Name:      params.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/fleet/get_bundle_test.go
+++ b/pkg/toolsets/fleet/get_bundle_test.go
@@ -47,16 +47,11 @@ func bundleScheme() *runtime.Scheme {
 }
 
 func TestGetBundle(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	tests := map[string]struct {
-		params        getBundleParams
-		fakeDynClient *dynamicfake.FakeDynamicClient
-		// used in the CallToolRequest
-		requestURL string
-		// used in the creation of the Tools.
-		rancherURL     string
+		params         getBundleParams
+		fakeDynClient  *dynamicfake.FakeDynamicClient
 		expectedResult string
 		expectedError  string
 	}{
@@ -65,41 +60,6 @@ func TestGetBundle(t *testing.T) {
 				Name:      "bundle-1",
 				Workspace: "fleet-default",
 			},
-			requestURL: fakeUrl,
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(bundleScheme(), map[schema.GroupVersionResource]string{
-				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "bundles"}: "BundleList",
-			}, fakeBundle1),
-			expectedResult: `{
-				"llm": [
-					{
-						"apiVersion": "fleet.cattle.io/v1alpha1",
-						"kind": "Bundle",
-						"metadata": {"name": "bundle-1", "namespace": "fleet-default"},
-						"spec": {
-							"targets": [{"clusterName": "cluster-1"}]
-						},
-						"status": {
-							"conditions": [{"type": "Ready", "status": "True"}]
-						}
-					}
-				],
-				"uiContext": [
-					{
-						"cluster": "local",
-						"kind": "Bundle",
-						"name": "bundle-1",
-						"namespace": "fleet-default",
-						"type": "fleet.cattle.io.bundle"
-					}
-				]
-			}`,
-		},
-		"get bundle when tool is configured with URL": {
-			params: getBundleParams{
-				Name:      "bundle-1",
-				Workspace: "fleet-default",
-			},
-			rancherURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(bundleScheme(), map[schema.GroupVersionResource]string{
 				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "bundles"}: "BundleList",
 			}, fakeBundle1),
@@ -133,21 +93,10 @@ func TestGetBundle(t *testing.T) {
 				Name:      "nonexistent-bundle",
 				Workspace: "fleet-default",
 			},
-			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(bundleScheme(), map[schema.GroupVersionResource]string{
 				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "bundles"}: "BundleList",
 			}),
 			expectedError: `nonexistent-bundle" not found`,
-		},
-		"get bundle - no rancherURL or request URL": {
-			params: getBundleParams{
-				Name:      "bundle-1",
-				Workspace: "fleet-default",
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(bundleScheme(), map[schema.GroupVersionResource]string{
-				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "bundles"}: "BundleList",
-			}),
-			expectedError: "no URL for rancher request",
 		},
 	}
 
@@ -158,8 +107,8 @@ func TestGetBundle(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken))
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.getBundle(
 				middleware.WithToken(t.Context(), fakeToken),

--- a/pkg/toolsets/fleet/get_gitrepo.go
+++ b/pkg/toolsets/fleet/get_gitrepo.go
@@ -28,7 +28,6 @@ func (t *Tools) getGitRepo(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 		Kind:      "gitrepo",
 		Namespace: params.Workspace,
 		Name:      params.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/fleet/get_gitrepo_test.go
+++ b/pkg/toolsets/fleet/get_gitrepo_test.go
@@ -15,16 +15,11 @@ import (
 )
 
 func TestGetGitRepo(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	tests := map[string]struct {
-		params        getGitRepoParams
-		fakeDynClient *dynamicfake.FakeDynamicClient
-		// used in the CallToolRequest
-		requestURL string
-		// used in the creation of the Tools.
-		rancherURL     string
+		params         getGitRepoParams
+		fakeDynClient  *dynamicfake.FakeDynamicClient
 		expectedResult string
 		expectedError  string
 	}{
@@ -33,7 +28,6 @@ func TestGetGitRepo(t *testing.T) {
 				Name:      "gitrepo-1",
 				Workspace: "fleet-default",
 			},
-			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
 				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
 			}, fakeGitRepo1, fakeGitRepo2),
@@ -69,21 +63,10 @@ func TestGetGitRepo(t *testing.T) {
 				Name:      "nonexistent-gitrepo",
 				Workspace: "fleet-default",
 			},
-			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
 				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
 			}),
 			expectedError: `nonexistent-gitrepo" not found`,
-		},
-		"get gitrepo - no rancherURL or request URL": {
-			params: getGitRepoParams{
-				Name:      "gitrepo-1",
-				Workspace: "fleet-default",
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
-				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
-			}),
-			expectedError: "no URL for rancher request",
 		},
 	}
 
@@ -94,8 +77,8 @@ func TestGetGitRepo(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken))
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.getGitRepo(
 				middleware.WithToken(t.Context(), fakeToken),

--- a/pkg/toolsets/fleet/list_gitrepos.go
+++ b/pkg/toolsets/fleet/list_gitrepos.go
@@ -25,7 +25,6 @@ func (t *Tools) listGitRepos(ctx context.Context, toolReq *mcp.CallToolRequest, 
 		Cluster:   "local",
 		Kind:      "gitrepo",
 		Namespace: params.Workspace,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {

--- a/pkg/toolsets/fleet/list_gitrepos_test.go
+++ b/pkg/toolsets/fleet/list_gitrepos_test.go
@@ -82,16 +82,11 @@ func listGitReposScheme() *runtime.Scheme {
 }
 
 func TestListGitRepos(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	tests := map[string]struct {
-		params        listGitRepoParams
-		fakeDynClient *dynamicfake.FakeDynamicClient
-		// used in the CallToolRequest
-		requestURL string
-		// used in the creation of the Tools.
-		rancherURL     string
+		params         listGitRepoParams
+		fakeDynClient  *dynamicfake.FakeDynamicClient
 		expectedResult string
 		expectedError  string
 	}{
@@ -99,7 +94,6 @@ func TestListGitRepos(t *testing.T) {
 			params: listGitRepoParams{
 				Workspace: "fleet-default",
 			},
-			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
 				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
 			}, fakeGitRepo1, fakeGitRepo2),
@@ -154,72 +148,10 @@ func TestListGitRepos(t *testing.T) {
 			params: listGitRepoParams{
 				Workspace: "empty-workspace",
 			},
-			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
 				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
 			}),
 			expectedResult: `{"llm": "no resources found"}`,
-		},
-		"list repos when tool is configured with URL": {
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
-				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
-			}, fakeGitRepo1, fakeGitRepo2),
-			rancherURL: fakeUrl,
-			expectedResult: `{
-				"llm": [
-					{
-						"apiVersion": "fleet.cattle.io/v1alpha1",
-						"kind": "GitRepo",
-						"metadata": {"name": "gitrepo-1", "namespace": "fleet-default"},
-						"spec": {
-							"repo": "https://github.com/example/repo1",
-							"paths": ["charts/"],
-							"targets": [{"clusterName": "cluster-1"}]
-						},
-						"status": {
-							"conditions": [{"type": "Ready", "status": "True"}]
-						}
-					},
-					{
-						"apiVersion": "fleet.cattle.io/v1alpha1",
-						"kind": "GitRepo",
-						"metadata": {"name": "gitrepo-2", "namespace": "fleet-default"},
-						"spec": {
-							"repo": "https://github.com/example/repo2",
-							"paths": ["manifests/"],
-							"targets": [{"clusterName": "cluster-2"}]
-						},
-						"status": {
-							"conditions": [{"type": "Ready", "status": "True"}]
-						}
-					}
-				],
-				"uiContext": [
-					{
-						"cluster": "local",
-						"kind": "GitRepo",
-						"name": "gitrepo-1",
-						"namespace": "fleet-default",
-						"type": "fleet.cattle.io.gitrepo"
-					},
-					{
-						"cluster": "local",
-						"kind": "GitRepo",
-						"name": "gitrepo-2",
-						"namespace": "fleet-default",
-						"type": "fleet.cattle.io.gitrepo"
-					}
-				]
-			}`,
-		},
-		"list gitrepos - no rancherURL or request URL": {
-			params: listGitRepoParams{
-				Workspace: "empty-workspace",
-			},
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listGitReposScheme(), map[schema.GroupVersionResource]string{
-				{Group: "fleet.cattle.io", Version: "v1alpha1", Resource: "gitrepos"}: "GitRepoList",
-			}),
-			expectedError: "no URL for rancher request",
 		},
 	}
 
@@ -230,8 +162,8 @@ func TestListGitRepos(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken))
+			req := &mcp.CallToolRequest{}
 
 			result, _, err := tools.listGitRepos(
 				middleware.WithToken(t.Context(), fakeToken),

--- a/pkg/toolsets/fleet/tools.go
+++ b/pkg/toolsets/fleet/tools.go
@@ -12,12 +12,12 @@ import (
 const (
 	toolsSet    = "fleet"
 	toolsSetAnn = "toolset"
-	urlHeader   = "R_url"
 )
 
 type toolsClient interface {
 	GetResource(ctx context.Context, params client.GetParams) (*unstructured.Unstructured, error)
 	GetResources(ctx context.Context, params client.ListParams) ([]*unstructured.Unstructured, error)
+	CreateRestConfig(token string, clusterID string) (*rest.Config, error)
 }
 
 type resourceAnalyzer interface {
@@ -27,25 +27,15 @@ type resourceAnalyzer interface {
 // Tools contains all tools for the MCP server
 type Tools struct {
 	client           toolsClient
-	RancherURL       string
 	resourceAnalyzer resourceAnalyzer
 }
 
 // NewTools creates and returns a new Tools instance.
-func NewTools(client toolsClient, rancherURL string) *Tools {
+func NewTools(client toolsClient) *Tools {
 	return &Tools{
 		client:           client,
-		RancherURL:       rancherURL,
 		resourceAnalyzer: newCLI(),
 	}
-}
-
-func (t *Tools) rancherURL(toolReq *mcp.CallToolRequest) string {
-	if t.RancherURL == "" {
-		return toolReq.Extra.Header.Get(urlHeader)
-	}
-
-	return t.RancherURL
 }
 
 // AddTools registers all Rancher Kubernetes tools with the provided MCP server.

--- a/pkg/toolsets/provisioning/analyze_cluster.go
+++ b/pkg/toolsets/provisioning/analyze_cluster.go
@@ -66,7 +66,6 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 		// Unlike provisioning clusters, management cluster objects are cluster scoped.
 		Namespace: "",
 		Name:      provCluster.Status.ClusterName,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -90,7 +89,6 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 		Kind:      converter.CAPIClusterResourceKind,
 		Namespace: DefaultClusterResourcesNamespace,
 		Name:      provCluster.Name,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/toolsets/provisioning/analyze_cluster_machines_test.go
+++ b/pkg/toolsets/provisioning/analyze_cluster_machines_test.go
@@ -133,17 +133,12 @@ var fakeCAPIMachineDeployment = &unstructured.Unstructured{
 }
 
 func TestAnalyzeClusterMachines(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
 	tests := map[string]struct {
-		params        inspectClusterMachinesParams
-		fakeClientset kubernetes.Interface
-		fakeDynClient *dynamicfake.FakeDynamicClient
-		// used in the CallToolRequest
-		requestURL string
-		// used in the creation of the Tools.
-		rancherURL     string
+		params         inspectClusterMachinesParams
+		fakeClientset  kubernetes.Interface
+		fakeDynClient  *dynamicfake.FakeDynamicClient
 		expectedResult string
 		expectedError  string
 	}{
@@ -152,7 +147,6 @@ func TestAnalyzeClusterMachines(t *testing.T) {
 				Cluster:   "test-cluster",
 				Namespace: "fleet-default",
 			},
-			requestURL:    testURL,
 			fakeClientset: newFakeClientSet(),
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds(),
 				fakeCAPIMachine, fakeCAPIMachine2, fakeCAPIMachineSet, fakeCAPIMachineDeployment),
@@ -301,7 +295,6 @@ func TestAnalyzeClusterMachines(t *testing.T) {
 				Cluster:   "empty-cluster",
 				Namespace: "fleet-default",
 			},
-			requestURL:     testURL,
 			fakeClientset:  newFakeClientSet(),
 			fakeDynClient:  dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds()),
 			expectedResult: `{"llm":"no resources found"}`,
@@ -311,7 +304,6 @@ func TestAnalyzeClusterMachines(t *testing.T) {
 				Cluster:   "test-cluster",
 				Namespace: "",
 			},
-			requestURL:    testURL,
 			fakeClientset: newFakeClientSet(),
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds(),
 				fakeCAPIMachine, fakeCAPIMachineSet, fakeCAPIMachineDeployment),
@@ -428,7 +420,6 @@ func TestAnalyzeClusterMachines(t *testing.T) {
 				Cluster:   "test-cluster",
 				Namespace: "fleet-default",
 			},
-			requestURL:    testURL,
 			fakeClientset: newFakeClientSet(),
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds(),
 				fakeCAPIMachine),
@@ -482,19 +473,9 @@ func TestAnalyzeClusterMachines(t *testing.T) {
 				Cluster:   "empty-cluster",
 				Namespace: "fleet-default",
 			},
-			rancherURL:     testURL,
 			fakeClientset:  newFakeClientSet(),
 			fakeDynClient:  dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds()),
 			expectedResult: `{"llm":"no resources found"}`,
-		},
-		"analyze cluster machines - no rancherURL or request URL": {
-			params: inspectClusterMachinesParams{
-				Cluster:   "empty-cluster",
-				Namespace: "fleet-default",
-			},
-			fakeClientset: newFakeClientSet(),
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds()),
-			expectedError: "no URL for rancher request",
 		},
 	}
 
@@ -509,8 +490,8 @@ func TestAnalyzeClusterMachines(t *testing.T) {
 				},
 			}
 
-			tools := NewTools(test.WrapClient(c, fakeToken, fakeUrl), tt.rancherURL, false)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, fakeToken), false)
+			req := &mcp.CallToolRequest{}
 			req.Params = &mcp.CallToolParamsRaw{
 				Name: "analyze-cluster-machines",
 			}

--- a/pkg/toolsets/provisioning/analyze_cluster_test.go
+++ b/pkg/toolsets/provisioning/analyze_cluster_test.go
@@ -1442,18 +1442,6 @@ func TestAnalyzeCluster(t *testing.T) {
 				]
 			}`,
 		},
-		"analyze cluster - no rancherURL or request URL": {
-			params: inspectClusterParams{
-				Cluster:   "test-cluster",
-				Namespace: "fleet-default",
-			},
-			fakeClientset: newFakeClientSet(),
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds(),
-				newProvisioningCluster("test-cluster", "fleet-default", "c-m-abc123"),
-				newManagementCluster("c-m-abc123", true),
-			),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -1466,8 +1454,8 @@ func TestAnalyzeCluster(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, testToken, testURL), tt.rancherURL, false)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, testToken), false)
+			req := &mcp.CallToolRequest{}
 			req.Params = &mcp.CallToolParamsRaw{Name: "analyze-cluster"}
 
 			result, _, err := tools.analyzeCluster(middleware.WithToken(t.Context(), testToken), req, tt.params)

--- a/pkg/toolsets/provisioning/create_custom_cluster.go
+++ b/pkg/toolsets/provisioning/create_custom_cluster.go
@@ -46,7 +46,7 @@ func (t *Tools) createCustomCluster(ctx context.Context, toolReq *mcp.CallToolRe
 		return nil, nil, fmt.Errorf("failed to create custom cluster object: %w", err)
 	}
 
-	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), t.rancherURL(toolReq), DefaultClusterResourcesNamespace, LocalCluster, converter.K8sKindsToGVRs[converter.ProvisioningClusterResourceKind])
+	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), DefaultClusterResourcesNamespace, LocalCluster, converter.K8sKindsToGVRs[converter.ProvisioningClusterResourceKind])
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting resource interface: %w", err)
 	}
@@ -85,7 +85,7 @@ func (t *Tools) CreateCustomClusterObj(toolReq *mcp.CallToolRequest, params crea
 		return nil, fmt.Errorf("unsupported CNI \"%s\". Valid values are \"%v\"", params.CNI, strings.Join(allCNIs, "\", \""))
 	}
 
-	fullVersion, allSupportedVersions, supported, err := supportedKubernetesVersion(t.rancherURL(toolReq), params.Distribution, params.Version, log)
+	fullVersion, allSupportedVersions, supported, err := supportedKubernetesVersion(t.client.RancherURL(), params.Distribution, params.Version, log)
 	if err != nil {
 		log.Error("error getting supported Kubernetes version", zap.Error(err))
 		return nil, fmt.Errorf("error checking supported Kubernetes versions: %w", err)

--- a/pkg/toolsets/provisioning/create_custom_cluster_plan_test.go
+++ b/pkg/toolsets/provisioning/create_custom_cluster_plan_test.go
@@ -169,16 +169,6 @@ func TestCreateCustomClusterPlan(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := &client.Client{
-				ClientSetCreator: func(inConfig *rest.Config) (kubernetes.Interface, error) {
-					return test.fakeClientset, nil
-				},
-				DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
-					return test.fakeDynClient, nil
-				},
-			}
-			tools := Tools{client: c}
-
 			// setup dummy KDM endpoint
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -189,11 +179,22 @@ func TestCreateCustomClusterPlan(t *testing.T) {
 				}
 			}))
 
+			c, err := client.NewClient(false, svr.URL)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+			c.ClientSetCreator = func(inConfig *rest.Config) (kubernetes.Interface, error) {
+				return test.fakeClientset, nil
+			}
+			c.DynClientCreator = func(inConfig *rest.Config) (dynamic.Interface, error) {
+				return test.fakeDynClient, nil
+			}
+			tools := Tools{client: c}
+
 			result, _, err := tools.createCustomClusterPlan(context.Background(), &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Name: "createCustomClusterPlan",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {svr.URL}}},
 			}, test.params)
 
 			if test.expectedError != "" {

--- a/pkg/toolsets/provisioning/create_custom_cluster_test.go
+++ b/pkg/toolsets/provisioning/create_custom_cluster_test.go
@@ -169,16 +169,6 @@ func TestCreateCustomCluster(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := &client.Client{
-				ClientSetCreator: func(inConfig *rest.Config) (kubernetes.Interface, error) {
-					return test.fakeClientset, nil
-				},
-				DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
-					return test.fakeDynClient, nil
-				},
-			}
-			tools := Tools{client: c}
-
 			// setup dummy KDM endpoint
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -189,11 +179,22 @@ func TestCreateCustomCluster(t *testing.T) {
 				}
 			}))
 
+			c, err := client.NewClient(false, svr.URL)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+			c.ClientSetCreator = func(inConfig *rest.Config) (kubernetes.Interface, error) {
+				return test.fakeClientset, nil
+			}
+			c.DynClientCreator = func(inConfig *rest.Config) (dynamic.Interface, error) {
+				return test.fakeDynClient, nil
+			}
+			tools := Tools{client: c}
+
 			result, _, err := tools.createCustomCluster(context.Background(), &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Name: "createCustomCluster",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {svr.URL}}},
 			}, test.params)
 
 			if test.expectedError != "" {

--- a/pkg/toolsets/provisioning/create_imported_cluster.go
+++ b/pkg/toolsets/provisioning/create_imported_cluster.go
@@ -42,7 +42,7 @@ func (t *Tools) createImportedCluster(ctx context.Context, toolReq *mcp.CallTool
 		return nil, nil, fmt.Errorf("failed to marshal cluster object to JSON: %w", err)
 	}
 
-	respBody, status, err := makeRancherRequest(ctx, t.rancherURL(toolReq), http.MethodPost, "v3/clusters", middleware.Token(ctx), clusterJSON)
+	respBody, status, err := makeRancherRequest(ctx, t.client.RancherURL(), http.MethodPost, "v3/clusters", middleware.Token(ctx), clusterJSON)
 	if err != nil {
 		log.Error("failed to make request to Rancher API to create imported cluster", zap.Error(err))
 		return nil, nil, fmt.Errorf("failed to make request to Rancher API to create imported cluster: %w", err)

--- a/pkg/toolsets/provisioning/create_imported_cluster_plan_test.go
+++ b/pkg/toolsets/provisioning/create_imported_cluster_plan_test.go
@@ -190,10 +190,10 @@ func TestCreateImportedClusterPlan(t *testing.T) {
 				Params: &mcp.CallToolParamsRaw{
 					Name: "createImportedClusterPlan",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {testURL}}},
 			}, test.params)
 
 			if test.expectedError != "" {
+				require.Error(t, err)
 				assert.ErrorContains(t, err, test.expectedError)
 			} else {
 				assert.NoError(t, err)

--- a/pkg/toolsets/provisioning/create_imported_cluster_test.go
+++ b/pkg/toolsets/provisioning/create_imported_cluster_test.go
@@ -96,16 +96,6 @@ func TestCreateImportedCluster(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := &client.Client{
-				ClientSetCreator: func(inConfig *rest.Config) (kubernetes.Interface, error) {
-					return newFakeClientSet(), nil
-				},
-				DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
-					return dynamicfake.NewSimpleDynamicClient(provisioningSchemes()), nil
-				},
-			}
-			tools := Tools{client: c}
-
 			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(test.serverStatus)
 				w.Write([]byte(test.serverBody))
@@ -117,11 +107,22 @@ func TestCreateImportedCluster(t *testing.T) {
 				defer svr.Close()
 			}
 
+			c, err := client.NewClient(false, svr.URL)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+			c.ClientSetCreator = func(inConfig *rest.Config) (kubernetes.Interface, error) {
+				return newFakeClientSet(), nil
+			}
+			c.DynClientCreator = func(inConfig *rest.Config) (dynamic.Interface, error) {
+				return dynamicfake.NewSimpleDynamicClient(provisioningSchemes()), nil
+			}
+			tools := Tools{client: c}
+
 			result, _, err := tools.createImportedCluster(context.Background(), &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Name: "createImportedCluster",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {svr.URL}}},
 			}, test.params)
 
 			if test.expectedError != "" {

--- a/pkg/toolsets/provisioning/create_k3k_cluster.go
+++ b/pkg/toolsets/provisioning/create_k3k_cluster.go
@@ -138,7 +138,7 @@ func (t *Tools) createK3kCluster(ctx context.Context, toolReq *mcp.CallToolReque
 
 	unstructuredObj := t.createK3kClusterObj(params)
 
-	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), toolReq.Extra.Header.Get(urlHeader), params.Namespace, params.TargetCluster, converter.K8sKindsToGVRs["k3kcluster"])
+	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), params.Namespace, params.TargetCluster, converter.K8sKindsToGVRs["k3kcluster"])
 	if err != nil {
 		zap.L().Error("failed to get resource interface", zap.String("tool", "createK3kCluster"), zap.Error(err))
 		return nil, nil, err

--- a/pkg/toolsets/provisioning/create_k3k_cluster_test.go
+++ b/pkg/toolsets/provisioning/create_k3k_cluster_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestCreateK3kCluster(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 	scheme := runtime.NewScheme()
 
@@ -135,9 +134,7 @@ func TestCreateK3kCluster(t *testing.T) {
 			}
 			tools := Tools{client: c}
 
-			result, _, err := tools.createK3kCluster(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-			}, test.params)
+			result, _, err := tools.createK3kCluster(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, test.params)
 
 			if test.expectedError != "" {
 				assert.ErrorContains(t, err, test.expectedError)

--- a/pkg/toolsets/provisioning/get_cluster_machine_test.go
+++ b/pkg/toolsets/provisioning/get_cluster_machine_test.go
@@ -341,15 +341,6 @@ func TestGetClusterMachine(t *testing.T) {
 			fakeDynClient:  dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds()),
 			expectedResult: `{"llm":"no resources found"}`,
 		},
-		"get machines from cluster - no rancherURL or request URL": {
-			params: getClusterMachineParams{
-				Cluster:     "empty-cluster",
-				MachineName: "",
-			},
-			fakeClientset: newFakeClientSet(),
-			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(provisioningSchemes(), provisioningCustomListKinds()),
-			expectedError: "no URL for rancher request",
-		},
 	}
 
 	for name, tt := range tests {
@@ -362,8 +353,8 @@ func TestGetClusterMachine(t *testing.T) {
 					return tt.fakeDynClient, nil
 				},
 			}
-			tools := NewTools(test.WrapClient(c, testToken, testURL), tt.rancherURL, false)
-			req := test.NewCallToolRequest(tt.requestURL)
+			tools := NewTools(test.WrapClient(c, testToken), false)
+			req := &mcp.CallToolRequest{}
 			req.Params = &mcp.CallToolParamsRaw{Name: "get-cluster-machine"}
 
 			result, _, err := tools.getClusterMachine(middleware.WithToken(t.Context(), testToken), req, tt.params)

--- a/pkg/toolsets/provisioning/get_k3k_clusters.go
+++ b/pkg/toolsets/provisioning/get_k3k_clusters.go
@@ -33,7 +33,6 @@ func (t *Tools) getK3kClusters(ctx context.Context, toolReq *mcp.CallToolRequest
 		clusterList, err := t.client.GetResources(ctx, client.ListParams{
 			Cluster: "local",
 			Kind:    "managementcluster",
-			URL:     toolReq.Extra.Header.Get(urlHeader),
 			Token:   middleware.Token(ctx),
 		})
 		if err != nil {
@@ -51,7 +50,6 @@ func (t *Tools) getK3kClusters(ctx context.Context, toolReq *mcp.CallToolRequest
 		k3kClusters, err := t.client.GetResources(ctx, client.ListParams{
 			Cluster: cluster,
 			Kind:    "k3kcluster",
-			URL:     toolReq.Extra.Header.Get(urlHeader),
 			Token:   middleware.Token(ctx),
 		})
 

--- a/pkg/toolsets/provisioning/get_k3k_clusters_test.go
+++ b/pkg/toolsets/provisioning/get_k3k_clusters_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestGetK3kClusters(t *testing.T) {
-	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 	scheme := runtime.NewScheme()
 
@@ -85,9 +84,7 @@ func TestGetK3kClusters(t *testing.T) {
 			}
 			tools := Tools{client: c}
 
-			result, _, err := tools.getK3kClusters(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {fakeUrl}}},
-			}, test.params)
+			result, _, err := tools.getK3kClusters(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, test.params)
 
 			if test.expectedError != "" {
 				assert.ErrorContains(t, err, test.expectedError)

--- a/pkg/toolsets/provisioning/list_supported_k8s_versions.go
+++ b/pkg/toolsets/provisioning/list_supported_k8s_versions.go
@@ -27,7 +27,7 @@ func (t *Tools) listSupportedKubernetesVersions(_ context.Context, toolReq *mcp.
 
 	log.Debug("listSupportedKubernetesVersions called")
 
-	versions, err := getKDMReleases(t.rancherURL(toolReq), params.Distribution)
+	versions, err := getKDMReleases(t.client.RancherURL(), params.Distribution)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/toolsets/provisioning/list_supported_k8s_versions_test.go
+++ b/pkg/toolsets/provisioning/list_supported_k8s_versions_test.go
@@ -46,14 +46,16 @@ func TestListSupportedKubernetesVersions(t *testing.T) {
 				w.Write([]byte(test.kdmOutput))
 			}))
 
-			c := &client.Client{}
+			c, err := client.NewClient(false, svr.URL)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
 			tools := Tools{client: c}
 
 			result, _, err := tools.listSupportedKubernetesVersions(context.Background(), &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Name: "listSupportedKubernetesVersions",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {svr.URL}}},
 			}, test.params)
 
 			if test.expectedError != "" {

--- a/pkg/toolsets/provisioning/provisioning_utils.go
+++ b/pkg/toolsets/provisioning/provisioning_utils.go
@@ -53,7 +53,6 @@ func (t *Tools) getCAPIMachineResourcesByName(ctx context.Context, toolReq *mcp.
 		Kind:      converter.CAPIMachineResourceKind,
 		Namespace: params.namespace,
 		Name:      params.machineName,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {
@@ -91,7 +90,6 @@ func (t *Tools) getCAPIMachineResourcesByName(ctx context.Context, toolReq *mcp.
 			Kind:      converter.CAPIMachineSetResourceKind,
 			Namespace: params.namespace,
 			Name:      ownerRef.Name,
-			URL:       t.rancherURL(toolReq),
 			Token:     middleware.Token(ctx),
 		})
 		if err != nil {
@@ -133,7 +131,6 @@ func (t *Tools) getCAPIMachineResourcesByName(ctx context.Context, toolReq *mcp.
 			Kind:      converter.CAPIMachineDeploymentResourceKind,
 			Namespace: params.namespace,
 			Name:      ownerRef.Name,
-			URL:       t.rancherURL(toolReq),
 			Token:     middleware.Token(ctx),
 		})
 		if err != nil {
@@ -199,7 +196,6 @@ func (t *Tools) getAllCAPIMachineResources(ctx context.Context, toolReq *mcp.Cal
 		Kind:          converter.CAPIMachineDeploymentResourceKind,
 		Namespace:     params.namespace,
 		LabelSelector: clusterSelector.String(),
-		URL:           t.rancherURL(toolReq),
 		Token:         middleware.Token(ctx),
 	})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -229,7 +225,6 @@ func (t *Tools) getAllCAPIMachineResources(ctx context.Context, toolReq *mcp.Cal
 		Kind:          converter.CAPIMachineSetResourceKind,
 		Namespace:     params.namespace,
 		LabelSelector: clusterSelector.String(),
-		URL:           t.rancherURL(toolReq),
 		Token:         middleware.Token(ctx),
 	})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -259,7 +254,6 @@ func (t *Tools) getAllCAPIMachineResources(ctx context.Context, toolReq *mcp.Cal
 		Kind:          converter.CAPIMachineResourceKind,
 		Namespace:     params.namespace,
 		LabelSelector: clusterSelector.String(),
-		URL:           t.rancherURL(toolReq),
 		Token:         middleware.Token(ctx),
 	})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -294,7 +288,6 @@ func (t *Tools) getProvisioningCluster(ctx context.Context, toolReq *mcp.CallToo
 		Kind:      converter.ProvisioningClusterResourceKind,
 		Namespace: ns,
 		Name:      clusterName,
-		URL:       t.rancherURL(toolReq),
 		Token:     middleware.Token(ctx),
 	})
 	if err != nil {
@@ -367,7 +360,6 @@ func (t *Tools) getMachinePoolConfigs(ctx context.Context, toolReq *mcp.CallTool
 			Cluster:   LocalCluster,
 			Namespace: DefaultClusterResourcesNamespace,
 			Name:      configName,
-			URL:       t.rancherURL(toolReq),
 			Token:     middleware.Token(ctx),
 		}, schema.GroupVersionResource{
 			Group:    "rke-machine-config.cattle.io",

--- a/pkg/toolsets/provisioning/scale_node_pool.go
+++ b/pkg/toolsets/provisioning/scale_node_pool.go
@@ -42,7 +42,7 @@ func (t *Tools) scaleClusterNodePool(ctx context.Context, toolReq *mcp.CallToolR
 
 	log.Debug("Scaling cluster node pool")
 
-	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), t.rancherURL(toolReq), params.Namespace, LocalCluster, converter.K8sKindsToGVRs[converter.ProvisioningClusterResourceKind])
+	resourceInterface, err := t.client.GetResourceInterface(ctx, middleware.Token(ctx), params.Namespace, LocalCluster, converter.K8sKindsToGVRs[converter.ProvisioningClusterResourceKind])
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/toolsets/provisioning/scale_node_pool_plan_test.go
+++ b/pkg/toolsets/provisioning/scale_node_pool_plan_test.go
@@ -510,7 +510,6 @@ func TestScaleNodePoolPlan(t *testing.T) {
 				Params: &mcp.CallToolParamsRaw{
 					Name: "scaleClusterNodePoolPlan",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {testURL}}},
 			}, test.params)
 
 			if test.expectedError != "" {

--- a/pkg/toolsets/provisioning/scale_node_pool_test.go
+++ b/pkg/toolsets/provisioning/scale_node_pool_test.go
@@ -608,7 +608,6 @@ func TestScaleNodePool(t *testing.T) {
 				Params: &mcp.CallToolParamsRaw{
 					Name: "scaleClusterNodePool",
 				},
-				Extra: &mcp.RequestExtra{Header: map[string][]string{urlHeader: {testURL}}},
 			}, test.params)
 
 			if test.expectedError != "" {

--- a/pkg/toolsets/provisioning/tools.go
+++ b/pkg/toolsets/provisioning/tools.go
@@ -13,7 +13,6 @@ import (
 const (
 	toolsSet    = "provisioning"
 	toolsSetAnn = "toolset"
-	urlHeader   = "R_url"
 )
 
 type toolsClient interface {
@@ -22,31 +21,22 @@ type toolsClient interface {
 	GetResourcesAtAnyAPIVersion(ctx context.Context, params client.ListParams) ([]*unstructured.Unstructured, error)
 	GetResourceByGVR(ctx context.Context, params client.GetParams, gvr schema.GroupVersionResource) (*unstructured.Unstructured, error)
 	GetResources(ctx context.Context, params client.ListParams) ([]*unstructured.Unstructured, error)
-	GetResourceInterface(ctx context.Context, token string, url string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error)
+	GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error)
+	RancherURL() string
 }
 
 // Tools contains tools for accessing provisioning information.
 type Tools struct {
-	client     toolsClient
-	RancherURL string
-	ReadOnly   bool
+	client   toolsClient
+	ReadOnly bool
 }
 
 // NewTools creates and returns a new Tools instance.
-func NewTools(client toolsClient, rancherURL string, readOnly bool) *Tools {
+func NewTools(client toolsClient, readOnly bool) *Tools {
 	return &Tools{
-		client:     client,
-		RancherURL: rancherURL,
-		ReadOnly:   readOnly,
+		client:   client,
+		ReadOnly: readOnly,
 	}
-}
-
-func (t *Tools) rancherURL(toolReq *mcp.CallToolRequest) string {
-	if t.RancherURL == "" {
-		return toolReq.Extra.Header.Get(urlHeader)
-	}
-
-	return t.RancherURL
 }
 
 func (t *Tools) AddTools(mcpServer *mcp.Server) {

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -14,19 +14,16 @@ type toolsAdder interface {
 }
 
 // AddAllTools adds all available tools to the MCP server.
-//
-// The rancherServerURL can be empty in which case we'll fall back to the R_url
-// value.
-func AddAllTools(client *client.Client, mcpServer *mcp.Server, rancherServerURL string, readOnly bool) {
-	for _, ta := range allToolSets(client, rancherServerURL, readOnly) {
+func AddAllTools(client *client.Client, mcpServer *mcp.Server, readOnly bool) {
+	for _, ta := range allToolSets(client, readOnly) {
 		ta.AddTools(mcpServer)
 	}
 }
 
-func allToolSets(client *client.Client, rancherURL string, readOnly bool) []toolsAdder {
+func allToolSets(client *client.Client, readOnly bool) []toolsAdder {
 	return []toolsAdder{
-		core.NewTools(client, rancherURL, readOnly),
-		fleet.NewTools(client, rancherURL),
-		provisioning.NewTools(client, rancherURL, readOnly),
+		core.NewTools(client, readOnly),
+		fleet.NewTools(client),
+		provisioning.NewTools(client, readOnly),
 	}
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllToolSets(t *testing.T) {
-	client := client.NewClient(true)
-	toolsets := allToolSets(client, "https://notused.example.com", false)
+	c, err := client.NewClient(true, "")
+	require.NoError(t, err)
+	toolsets := allToolSets(c, false)
 
 	assert.NotNil(t, toolsets)
 	assert.Len(t, toolsets, 3, "should have exactly 2 toolsets (core and fleet)")


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/204

### Problem
Currently, the public Rancher URL is passed via the `R_url` header. This is unnecessary overhead for internal cluster communication, as both the MCP and Agent pods reside within the local cluster.

### Solution

- Remove R_url: Cleaned up all code and references related to the `R_url` header.

- Internal Service Routing: Switched to using the internal Rancher service URL `https://rancher.cattle-system`

- External OAuth2 Fallback: Maintained support for external MCP usage (e.g., Claude Code, Gemini CLI). When running outside the cluster, OAuth2 will still utilize the public Rancher URL derived from the authz endpoint.