### PR TITLE
Use internal-server-url and internal-cacerts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,12 @@ go test -v -cover ./...
 go build -o mcp-server .
 ```
 
+### Running Locally for Development
+
+When running the MCP server locally (outside of a Kubernetes cluster), set the `RANCHER_URL` environment variable to point to your Rancher instance. This skips the in-cluster auto-detection and lets the server connect directly to your Rancher API:
+
+If `RANCHER_URL` is not set and the server is not running inside a cluster, startup will fail because it cannot auto-discover the Rancher URL.
+
 ### Project Structure
 
 ```

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -465,8 +465,8 @@ func fetchRancherURL() (string, error) {
 		return "", fmt.Errorf("getting internal-server-url setting: %w", err)
 	}
 
-	value, _, _ := unstructured.NestedString(obj.Object, "value")
-	return value, nil
+	value, _, err := unstructured.NestedString(obj.Object, "value")
+	return value, err
 }
 
 // fetchCABundle fetches the CA certificate from the Rancher internal-cacerts Setting

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,17 +59,20 @@ func NewClient(insecure bool, authzServerURL string) (*Client, error) {
 		return nil, fmt.Errorf("parsing authz-server-url: %w", err)
 	}
 	if rancherURL == "" {
-		if envURL := os.Getenv("RANCHER_API_TOKEN"); envURL != "" {
+		if envURL := os.Getenv("RANCHER_URL"); envURL != "" {
 			rancherURL = envURL
 		} else {
-			rancherURL = "https://rancher.cattle-system"
+			rancherURL, err = fetchRancherURL()
+			if err != nil {
+				return nil, fmt.Errorf("fetching internal-server-url from rancher: %w", err)
+			}
 		}
 	}
 	var caBundle []byte
 	if !insecure {
 		caBundle, err = fetchCABundle()
 		if err != nil {
-			return nil, fmt.Errorf("fetching cacerts from rancher: %w", err)
+			return nil, fmt.Errorf("fetching internal-cacerts from rancher: %w", err)
 		}
 	}
 	return &Client{
@@ -438,7 +441,35 @@ func (c *Client) getAPIVersionsForGR(ctx context.Context, token, cluster string,
 	return versions, nil
 }
 
-// fetchCABundle fetches the CA certificate from the Rancher cacerts Setting
+// fetchRancherURL fetches the Rancher server URL from the internal-server-url Setting
+// resource via the Kubernetes API using in-cluster config.
+func fetchRancherURL() (string, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return "", fmt.Errorf("creating in-cluster config: %w", err)
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "settings",
+	}
+
+	obj, err := dynClient.Resource(gvr).Get(context.Background(), "internal-server-url", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting internal-server-url setting: %w", err)
+	}
+
+	value, _, _ := unstructured.NestedString(obj.Object, "value")
+	return value, nil
+}
+
+// fetchCABundle fetches the CA certificate from the Rancher internal-cacerts Setting
 // resource via the Kubernetes API using in-cluster config.
 func fetchCABundle() ([]byte, error) {
 	cfg, err := rest.InClusterConfig()
@@ -457,9 +488,9 @@ func fetchCABundle() ([]byte, error) {
 		Resource: "settings",
 	}
 
-	obj, err := dynClient.Resource(gvr).Get(context.Background(), "cacerts", metav1.GetOptions{})
+	obj, err := dynClient.Resource(gvr).Get(context.Background(), "internal-cacerts", metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("getting cacerts setting: %w", err)
+		return nil, fmt.Errorf("getting internal-cacerts setting: %w", err)
 	}
 
 	value, _, _ := unstructured.NestedString(obj.Object, "value")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -493,13 +493,14 @@ func fetchCABundle() ([]byte, error) {
 		return nil, fmt.Errorf("getting internal-cacerts setting: %w", err)
 	}
 
-	value, _, _ := unstructured.NestedString(obj.Object, "value")
-	if value == "" {
+	value, found, err := unstructured.NestedString(obj.Object, "value")
+	if err != nil {
+		return nil, fmt.Errorf("reading internal-cacerts value: %w", err)
+	}
+	if !found || strings.TrimSpace(value) == "" {
 		return nil, nil
 	}
-
 	return []byte(value), nil
-}
 
 func rancherURLFromAuthServerURL(s string) (string, error) {
 	if s == "" {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -26,6 +27,7 @@ var clustersDisplayNameToIDCache = sync.Map{}
 type Client struct {
 	insecure         bool
 	rancherURL       string
+	caBundle         []byte
 	DynClientCreator func(*rest.Config) (dynamic.Interface, error)
 	ClientSetCreator func(*rest.Config) (kubernetes.Interface, error)
 }
@@ -57,9 +59,21 @@ func NewClient(insecure bool, authzServerURL string) (*Client, error) {
 		return nil, fmt.Errorf("parsing authz-server-url: %w", err)
 	}
 	if rancherURL == "" {
-		rancherURL = "https://rancher.cattle-system"
+		if envURL := os.Getenv("RANCHER_API_TOKEN"); envURL != "" {
+			rancherURL = envURL
+		} else {
+			rancherURL = "https://rancher.cattle-system"
+		}
+	}
+	var caBundle []byte
+	if !insecure {
+		caBundle, err = fetchCABundle()
+		if err != nil {
+			return nil, fmt.Errorf("fetching cacerts from rancher: %w", err)
+		}
 	}
 	return &Client{
+		caBundle:   caBundle,
 		insecure:   insecure,
 		rancherURL: rancherURL,
 		DynClientCreator: func(cfg *rest.Config) (dynamic.Interface, error) {
@@ -363,10 +377,15 @@ func (c *Client) GetClusterID(ctx context.Context, token string, clusterNameOrID
 func (c *Client) CreateRestConfig(token string, clusterID string) (*rest.Config, error) {
 	clusterURL := c.rancherURL + "/k8s/clusters/" + clusterID
 	kubeconfig := clientcmdapi.NewConfig()
-	kubeconfig.Clusters["Cluster"] = &clientcmdapi.Cluster{
-		Server:                clusterURL,
-		InsecureSkipTLSVerify: c.insecure,
+	cluster := &clientcmdapi.Cluster{
+		Server: clusterURL,
 	}
+	if c.insecure {
+		cluster.InsecureSkipTLSVerify = true
+	} else if len(c.caBundle) > 0 {
+		cluster.CertificateAuthorityData = c.caBundle
+	}
+	kubeconfig.Clusters["Cluster"] = cluster
 	kubeconfig.AuthInfos["mcp"] = &clientcmdapi.AuthInfo{
 		Token: token,
 	}
@@ -417,6 +436,38 @@ func (c *Client) getAPIVersionsForGR(ctx context.Context, token, cluster string,
 		}
 	}
 	return versions, nil
+}
+
+// fetchCABundle fetches the CA certificate from the Rancher cacerts Setting
+// resource via the Kubernetes API using in-cluster config.
+func fetchCABundle() ([]byte, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("creating in-cluster config: %w", err)
+	}
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "management.cattle.io",
+		Version:  "v3",
+		Resource: "settings",
+	}
+
+	obj, err := dynClient.Resource(gvr).Get(context.Background(), "cacerts", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting cacerts setting: %w", err)
+	}
+
+	value, _, _ := unstructured.NestedString(obj.Object, "value")
+	if value == "" {
+		return nil, nil
+	}
+
+	return []byte(value), nil
 }
 
 func rancherURLFromAuthServerURL(s string) (string, error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -501,6 +501,7 @@ func fetchCABundle() ([]byte, error) {
 		return nil, nil
 	}
 	return []byte(value), nil
+}
 
 func rancherURLFromAuthServerURL(s string) (string, error) {
 	if s == "" {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 
@@ -368,6 +369,103 @@ func TestRancherURLFromAuthServerURL(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestCreateRestConfig(t *testing.T) {
+	tests := map[string]struct {
+		client             *Client
+		token              string
+		clusterID          string
+		expectInsecure     bool
+		expectCAData       []byte
+		expectServerSuffix string
+	}{
+		"insecure mode sets InsecureSkipTLSVerify": {
+			client: &Client{
+				insecure:   true,
+				rancherURL: fakeUrl,
+			},
+			token:              fakeToken,
+			clusterID:          "local",
+			expectInsecure:     true,
+			expectCAData:       nil,
+			expectServerSuffix: "/k8s/clusters/local",
+		},
+		"secure mode with caBundle sets CAData": {
+			client: &Client{
+				insecure:   false,
+				rancherURL: fakeUrl,
+				caBundle:   []byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"),
+			},
+			token:              fakeToken,
+			clusterID:          "c-m-12345",
+			expectInsecure:     false,
+			expectCAData:       []byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"),
+			expectServerSuffix: "/k8s/clusters/c-m-12345",
+		},
+		"secure mode without caBundle leaves both empty": {
+			client: &Client{
+				insecure:   false,
+				rancherURL: fakeUrl,
+				caBundle:   nil,
+			},
+			token:              fakeToken,
+			clusterID:          "local",
+			expectInsecure:     false,
+			expectCAData:       nil,
+			expectServerSuffix: "/k8s/clusters/local",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := test.client.CreateRestConfig(test.token, test.clusterID)
+			require.NoError(t, err)
+
+			assert.Contains(t, cfg.Host, test.expectServerSuffix)
+			assert.Equal(t, "Bearer "+fakeToken, "Bearer "+cfg.BearerToken)
+			assert.Equal(t, test.expectInsecure, cfg.TLSClientConfig.Insecure)
+			assert.Equal(t, test.expectCAData, cfg.TLSClientConfig.CAData)
+		})
+	}
+}
+
+func TestNewClient_RancherURL(t *testing.T) {
+	tests := map[string]struct {
+		authzServerURL string
+		envVar         string
+		expectedURL    string
+	}{
+		"uses authzServerURL when provided": {
+			authzServerURL: "https://rancher.example.com/v3-public/auth",
+			expectedURL:    "https://rancher.example.com",
+		},
+		"falls back to RANCHER_API_TOKEN env var": {
+			authzServerURL: "",
+			envVar:         "https://my-rancher.internal",
+			expectedURL:    "https://my-rancher.internal",
+		},
+		"falls back to default when no authz URL and no env var": {
+			authzServerURL: "",
+			envVar:         "",
+			expectedURL:    "https://rancher.cattle-system",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.envVar != "" {
+				t.Setenv("RANCHER_API_TOKEN", test.envVar)
+			} else {
+				os.Unsetenv("RANCHER_API_TOKEN")
+			}
+
+			// Use insecure=true to avoid fetchCABundle (requires in-cluster config)
+			c, err := NewClient(true, test.authzServerURL)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedURL, c.RancherURL())
 		})
 	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -442,27 +442,21 @@ func TestNewClient_RancherURL(t *testing.T) {
 			authzServerURL: "https://rancher.example.com/v3-public/auth",
 			expectedURL:    "https://rancher.example.com",
 		},
-		"falls back to RANCHER_API_TOKEN env var": {
+		"falls back to RANCHER_URL env var": {
 			authzServerURL: "",
 			envVar:         "https://my-rancher.internal",
 			expectedURL:    "https://my-rancher.internal",
-		},
-		"falls back to default when no authz URL and no env var": {
-			authzServerURL: "",
-			envVar:         "",
-			expectedURL:    "https://rancher.cattle-system",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			if test.envVar != "" {
-				t.Setenv("RANCHER_API_TOKEN", test.envVar)
+				t.Setenv("RANCHER_URL", test.envVar)
 			} else {
-				os.Unsetenv("RANCHER_API_TOKEN")
+				os.Unsetenv("RANCHER_URL")
 			}
 
-			// Use insecure=true to avoid fetchCABundle (requires in-cluster config)
 			c, err := NewClient(true, test.authzServerURL)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedURL, c.RancherURL())

--- a/pkg/toolsets/provisioning/create_custom_cluster_plan_test.go
+++ b/pkg/toolsets/provisioning/create_custom_cluster_plan_test.go
@@ -179,7 +179,7 @@ func TestCreateCustomClusterPlan(t *testing.T) {
 				}
 			}))
 
-			c, err := client.NewClient(false, svr.URL)
+			c, err := client.NewClient(true, svr.URL)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}

--- a/pkg/toolsets/provisioning/create_custom_cluster_test.go
+++ b/pkg/toolsets/provisioning/create_custom_cluster_test.go
@@ -179,7 +179,7 @@ func TestCreateCustomCluster(t *testing.T) {
 				}
 			}))
 
-			c, err := client.NewClient(false, svr.URL)
+			c, err := client.NewClient(true, svr.URL)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}

--- a/pkg/toolsets/provisioning/create_imported_cluster_test.go
+++ b/pkg/toolsets/provisioning/create_imported_cluster_test.go
@@ -107,7 +107,7 @@ func TestCreateImportedCluster(t *testing.T) {
 				defer svr.Close()
 			}
 
-			c, err := client.NewClient(false, svr.URL)
+			c, err := client.NewClient(true, svr.URL)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}

--- a/pkg/toolsets/provisioning/list_supported_k8s_versions_test.go
+++ b/pkg/toolsets/provisioning/list_supported_k8s_versions_test.go
@@ -46,7 +46,7 @@ func TestListSupportedKubernetesVersions(t *testing.T) {
 				w.Write([]byte(test.kdmOutput))
 			}))
 
-			c, err := client.NewClient(false, svr.URL)
+			c, err := client.NewClient(true, svr.URL)
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAllToolSets(t *testing.T) {
-	c, err := client.NewClient(true, "")
+	c, err := client.NewClient(true, "https://fake-url")
 	require.NoError(t, err)
 	toolsets := allToolSets(c, false)
 


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-agent/issues/283

### Problem
When `insecureSkipTls=false`, the agent failed with an x509: certificate signed by unknown authority error because the CA certificate was not being loaded.

### Fix
CA Cert: Now explicitly loading the CA certificate from the `internal-cacerts` setting.
URL: Now loading the URL from the `internal-server-url` setting.

Related to https://github.com/rancher/rancher-ai-agent/pull/288