### PR TITLE
Include project members in getProject

### DIFF
--- a/pkg/toolsets/core/projects/get_project.go
+++ b/pkg/toolsets/core/projects/get_project.go
@@ -112,7 +112,29 @@ func (t *Tools) getProject(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 	}
 
 	resources := append([]*unstructured.Unstructured{projectResource}, projectNamespaces...)
-	resources = append(resources, projectMembers...)
+	for _, prtb := range projectMembers {
+		slim := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": prtb.GetAPIVersion(),
+				"kind":       prtb.GetKind(),
+				"metadata": map[string]any{
+					"name":      prtb.GetName(),
+					"namespace": prtb.GetNamespace(),
+				},
+			},
+		}
+		// Return only the subject identity and role instead of the full PRTB,
+		// which bloats the response for projects with many members.
+		// A PRTB is either a user binding (userName/userPrincipalName) or a group binding
+		// (groupName/groupPrincipalName), never both; copying only non-empty fields
+		// naturally produces the right pair without branching.
+		for _, field := range []string{"userName", "userPrincipalName", "groupName", "groupPrincipalName", "roleTemplateName"} {
+			if v, _, _ := unstructured.NestedString(prtb.Object, field); v != "" {
+				slim.Object[field] = v
+			}
+		}
+		resources = append(resources, slim)
+	}
 
 	mcpResponse, err := response.CreateMcpResponse(resources, clusterID)
 	if err != nil {

--- a/pkg/toolsets/core/projects/get_project.go
+++ b/pkg/toolsets/core/projects/get_project.go
@@ -100,7 +100,19 @@ func (t *Tools) getProject(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 		return nil, nil, err
 	}
 
+	projectMembers, err := t.client.GetResources(ctx, client.ListParams{
+		Cluster:   LocalCluster,
+		Kind:      "projectroletemplatebinding",
+		Namespace: projectID,
+		Token:     middleware.Token(ctx),
+	})
+	if err != nil {
+		zap.L().Error("failed to get members for project", zapGetProject, zap.Error(err))
+		return nil, nil, err
+	}
+
 	resources := append([]*unstructured.Unstructured{projectResource}, projectNamespaces...)
+	resources = append(resources, projectMembers...)
 
 	mcpResponse, err := response.CreateMcpResponse(resources, clusterID)
 	if err != nil {

--- a/pkg/toolsets/core/projects/get_project_test.go
+++ b/pkg/toolsets/core/projects/get_project_test.go
@@ -52,8 +52,9 @@ func TestGetProject(t *testing.T) {
 	_ = metav1.AddMetaToScheme(scheme)
 
 	customListKinds := map[schema.GroupVersionResource]string{
-		{Group: "management.cattle.io", Version: "v3", Resource: "clusters"}: "ClusterList",
-		{Group: "management.cattle.io", Version: "v3", Resource: "projects"}: "ProjectList",
+		{Group: "management.cattle.io", Version: "v3", Resource: "clusters"}:                    "ClusterList",
+		{Group: "management.cattle.io", Version: "v3", Resource: "projects"}:                    "ProjectList",
+		{Group: "management.cattle.io", Version: "v3", Resource: "projectroletemplatebindings"}: "ProjectRoleTemplateBindingList",
 	}
 
 	t.Run("get project with namespaces", func(t *testing.T) {
@@ -83,7 +84,21 @@ func TestGetProject(t *testing.T) {
 			},
 		}
 
-		fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, customListKinds, cluster, project, namespace1, namespace2)
+		member := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion":       "management.cattle.io/v3",
+				"kind":             "ProjectRoleTemplateBinding",
+				"userName":         "u-abc123",
+				"roleTemplateName": "project-owner",
+				"projectName":      "test-cluster:my-project",
+				"metadata": map[string]any{
+					"name":      "prtb-1",
+					"namespace": "my-project",
+				},
+			},
+		}
+
+		fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, customListKinds, cluster, project, namespace1, namespace2, member)
 
 		c := &client.Client{
 			DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
@@ -137,6 +152,17 @@ func TestGetProject(t *testing.T) {
             },
             "spec": {},
             "status": {}
+        },
+        {
+            "apiVersion": "management.cattle.io/v3",
+            "kind": "ProjectRoleTemplateBinding",
+            "metadata": {
+                "name": "prtb-1",
+                "namespace": "my-project"
+            },
+            "userName": "u-abc123",
+            "roleTemplateName": "project-owner",
+            "projectName": "test-cluster:my-project"
         }
     ],
     "uiContext": [
@@ -160,6 +186,13 @@ func TestGetProject(t *testing.T) {
             "name": "ns-2",
             "namespace": "",
             "type": "namespace"
+        },
+        {
+            "cluster": "test-cluster",
+            "kind": "ProjectRoleTemplateBinding",
+            "name": "prtb-1",
+            "namespace": "my-project",
+            "type": "projectroletemplatebinding"
         }
     ]
 }`

--- a/pkg/toolsets/core/projects/get_project_test.go
+++ b/pkg/toolsets/core/projects/get_project_test.go
@@ -161,8 +161,7 @@ func TestGetProject(t *testing.T) {
                 "namespace": "my-project"
             },
             "userName": "u-abc123",
-            "roleTemplateName": "project-owner",
-            "projectName": "test-cluster:my-project"
+            "roleTemplateName": "project-owner"
         }
     ],
     "uiContext": [
@@ -191,6 +190,88 @@ func TestGetProject(t *testing.T) {
             "cluster": "test-cluster",
             "kind": "ProjectRoleTemplateBinding",
             "name": "prtb-1",
+            "namespace": "my-project",
+            "type": "projectroletemplatebinding"
+        }
+    ]
+}`
+		text := result.Content[0].(*mcp.TextContent).Text
+		t.Logf("got result: %s", text)
+		assert.JSONEq(t, expectedResult, text)
+	})
+
+	t.Run("get project with group member", func(t *testing.T) {
+		t.Parallel()
+		groupMember := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion":         "management.cattle.io/v3",
+				"kind":               "ProjectRoleTemplateBinding",
+				"groupName":          "g-xyz789",
+				"groupPrincipalName": "ldap://cn=devs,dc=example,dc=com",
+				"roleTemplateName":   "project-member",
+				"projectName":        "test-cluster:my-project",
+				"metadata": map[string]any{
+					"name":      "prtb-2",
+					"namespace": "my-project",
+				},
+			},
+		}
+
+		fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, customListKinds, cluster, project, groupMember)
+
+		c := &client.Client{
+			DynClientCreator: func(inConfig *rest.Config) (dynamic.Interface, error) {
+				return fakeDynClient, nil
+			},
+		}
+		tools := Tools{client: newFakeToolsClient(c, fakeToken)}
+
+		result, _, err := tools.getProject(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, getProjectParams{
+			Name:    "my-project",
+			Cluster: "test-cluster",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Len(t, result.Content, 1)
+
+		expectedResult := `{
+    "llm": [
+        {
+            "apiVersion": "management.cattle.io/v3",
+            "kind": "Project",
+            "metadata": {
+                "name": "my-project",
+                "namespace": "test-cluster"
+            },
+            "spec": {
+                "displayName": "My Project"
+            }
+        },
+        {
+            "apiVersion": "management.cattle.io/v3",
+            "kind": "ProjectRoleTemplateBinding",
+            "metadata": {
+                "name": "prtb-2",
+                "namespace": "my-project"
+            },
+            "groupName": "g-xyz789",
+            "groupPrincipalName": "ldap://cn=devs,dc=example,dc=com",
+            "roleTemplateName": "project-member"
+        }
+    ],
+    "uiContext": [
+        {
+            "cluster": "test-cluster",
+            "kind": "Project",
+            "name": "my-project",
+            "namespace": "test-cluster",
+            "type": "project"
+        },
+        {
+            "cluster": "test-cluster",
+            "kind": "ProjectRoleTemplateBinding",
+            "name": "prtb-2",
             "namespace": "my-project",
             "type": "projectroletemplatebinding"
         }

--- a/pkg/toolsets/core/projects/tools.go
+++ b/pkg/toolsets/core/projects/tools.go
@@ -44,7 +44,7 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		Meta: map[string]any{
 			toolsSetAnn: toolsSet,
 		},
-		Description: `Returns a project resource and its associated namespaces.`},
+		Description: `Returns a project resource and its associated namespaces and members.`},
 		t.getProject,
 	)
 


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-mcp/issues/45

## Problem

The `getProject` tool returned a project and its namespaces but not its members, so callers could not see who had access to a project or with what role.

## Solution

`ProjectRoleTemplateBindings` for the project are now fetched and appended to the getProject output alongside the project and its namespaces.

This can be improved by resolving users for user members but requires N additional calls to fetch user and/or userattribute objects.