### PR TITLE
Add filtering and pagination to listKubernetesResources

### DIFF
--- a/pkg/toolsets/core/list_resources.go
+++ b/pkg/toolsets/core/list_resources.go
@@ -55,7 +55,7 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 	if params.JSONPath != "" {
 		resources, err = filterByJSONPath(resources, params.JSONPath)
 		if err != nil {
-			zap.L().Error("failed to filter resources by jsonpath", zap.String("tool", "listKubernetesResource"), zap.Error(err))
+			zap.L().Error("failed to filter resources by jsonpath", zap.String("tool", "listKubernetesResources"), zap.Error(err))
 			return nil, nil, err
 		}
 	}

--- a/pkg/toolsets/core/list_resources.go
+++ b/pkg/toolsets/core/list_resources.go
@@ -9,6 +9,8 @@ import (
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/response"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/jsonpath"
 )
 
 const defaultListLimit = 10
@@ -19,7 +21,9 @@ type listKubernetesResourcesParams struct {
 	Kind          string `json:"kind" jsonschema:"the type of Kubernetes resource (e.g., Pod, Deployment, Service)"`
 	Cluster       string `json:"cluster" jsonschema:"the name of the Kubernetes cluster"`
 	Limit         int64  `json:"limit,omitempty" jsonschema:"maximum number of resources to return, defaults to 10"`
+	Offset        int64  `json:"offset,omitempty" jsonschema:"number of resources to skip before returning results, defaults to 0. Used with limit for pagination"`
 	LabelSelector string `json:"labelSelector,omitempty" jsonschema:"optional label selector to filter resources (e.g. app=nginx)"`
+	JSONPath      string `json:"jsonPath,omitempty" jsonschema:"optional JSONPath filter predicate to select matching resources. Use @ to reference a resource, e.g. @.status.phase==\"Running\" or @.metadata.labels.app==\"nginx\". Only resources matching the predicate are returned"`
 }
 
 // listKubernetesResources lists Kubernetes resources of a specific kind and namespace.
@@ -29,6 +33,10 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 	limit := params.Limit
 	if limit <= 0 {
 		limit = defaultListLimit
+	}
+	offset := params.Offset
+	if offset < 0 {
+		offset = 0
 	}
 
 	resources, err := t.client.GetResources(ctx, client.ListParams{
@@ -43,16 +51,35 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 		return nil, nil, err
 	}
 
-	total := int64(len(resources))
-	truncated := total > limit
-	if truncated {
-		resources = resources[:limit]
+	if params.JSONPath != "" {
+		resources, err = filterByJSONPath(resources, params.JSONPath)
+		if err != nil {
+			zap.L().Error("failed to filter resources by jsonpath", zap.String("tool", "listKubernetesResource"), zap.Error(err))
+			return nil, nil, err
+		}
 	}
 
+	total := int64(len(resources))
+
+	// window the results in-memory: [offset, offset+limit)
+	start := min(offset, total)
+	end := min(offset+limit, total)
+	resources = resources[start:end]
+
+	hasMore := offset+limit < total
+
 	var mcpResponse string
-	if truncated {
-		note := fmt.Sprintf("Results were limited to %d items out of %d total. There may be more resources matching the query. "+
-			"Use a namespace or label selector to narrow results, or increase the limit.", limit, total)
+	if hasMore || offset > 0 {
+		filterSuffix := ""
+		if params.JSONPath != "" {
+			filterSuffix = " matching the JSONPath filter"
+		}
+		note := fmt.Sprintf("Returned %d resources (offset %d, limit %d) out of %d total%s. "+
+			"Use a namespace or label selector to narrow results, or increase the limit.",
+			len(resources), offset, limit, total, filterSuffix)
+		if hasMore {
+			note += fmt.Sprintf(" To get the next page, set offset=%d.", offset+limit)
+		}
 		mcpResponse, err = response.CreateMcpResponse(resources, params.Cluster, note)
 	} else {
 		mcpResponse, err = response.CreateMcpResponse(resources, params.Cluster)
@@ -65,4 +92,37 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
 	}, nil, nil
+}
+
+// filterByJSONPath returns the subset of objs matching the given JSONPath predicate
+// expression (the body of a kubectl-style [?(...)] filter, e.g. `@.status.phase=="Running"`).
+// The objects are wrapped as a list so the filter can iterate over them, mirroring
+// kubectl's `{.items[?(<predicate>)]}` selector semantics.
+func filterByJSONPath(objs []*unstructured.Unstructured, expr string) ([]*unstructured.Unstructured, error) {
+	items := make([]interface{}, len(objs))
+	for i, obj := range objs {
+		items[i] = obj.Object
+	}
+	input := map[string]interface{}{"items": items}
+
+	jp := jsonpath.New("filter").AllowMissingKeys(true)
+	if err := jp.Parse("{.items[?(" + expr + ")]}"); err != nil {
+		return nil, fmt.Errorf("invalid jsonPath filter %q: %w", expr, err)
+	}
+
+	results, err := jp.FindResults(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate jsonPath filter %q: %w", expr, err)
+	}
+
+	filtered := make([]*unstructured.Unstructured, 0)
+	for _, group := range results {
+		for _, v := range group {
+			if m, ok := v.Interface().(map[string]interface{}); ok {
+				filtered = append(filtered, &unstructured.Unstructured{Object: m})
+			}
+		}
+	}
+
+	return filtered, nil
 }

--- a/pkg/toolsets/core/list_resources.go
+++ b/pkg/toolsets/core/list_resources.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
@@ -14,14 +13,12 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 )
 
-const defaultListLimit = 10
-
 // listKubernetesResourcesParams specifies the parameters needed to list kubernetes resources.
 type listKubernetesResourcesParams struct {
 	Namespace     string `json:"namespace" jsonschema:"the namespace where the resources are located. It must be empty for all namespaces or cluster-wide resources"`
 	Kind          string `json:"kind" jsonschema:"the type of Kubernetes resource (e.g., Pod, Deployment, Service)"`
 	Cluster       string `json:"cluster" jsonschema:"the name of the Kubernetes cluster"`
-	Limit         int64  `json:"limit,omitempty" jsonschema:"maximum number of resources to return, defaults to 10. Do not change this value unless the user explicitly asks for a different page size or wants to see all the remaining results"`
+	Limit         int64  `json:"limit,omitempty" jsonschema:"maximum number of resources to return, defaults to 100"`
 	Offset        int64  `json:"offset,omitempty" jsonschema:"how many resources to skip from the start of the full list before returning results. Defaults to 0 (start at the first resource). Use it together with limit to page through results: set offset=0 for the first page, then increase offset by limit for each next page. For example, with limit=10: offset=0 returns resources 1-10, offset=10 returns resources 11-20, offset=20 returns resources 21-30. When more resources are available, the response tells you the exact offset to use for the next page"`
 	LabelSelector string `json:"labelSelector,omitempty" jsonschema:"optional label selector to filter resources (e.g. app=nginx)"`
 	JSONPath      string `json:"jsonPath,omitempty" jsonschema:"optional JSONPath filter predicate to select matching resources. Use @ to reference a resource, e.g. @.status.phase==\"Running\" or @.metadata.labels.app==\"nginx\". Only resources matching the predicate are returned"`
@@ -30,15 +27,6 @@ type listKubernetesResourcesParams struct {
 // listKubernetesResources lists Kubernetes resources of a specific kind and namespace.
 func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallToolRequest, params listKubernetesResourcesParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("listKubernetesResource called")
-
-	limit := params.Limit
-	if limit <= 0 {
-		limit = defaultListLimit
-	}
-	offset := params.Offset
-	if offset < 0 {
-		offset = 0
-	}
 
 	resources, err := t.client.GetResources(ctx, client.ListParams{
 		Cluster:       params.Cluster,
@@ -60,39 +48,18 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 		}
 	}
 
-	// The order of resources returned by the API is not guaranteed to be stable
-	// across calls, so sort by namespace/name to make offset pagination deterministic.
-	sort.Slice(resources, func(i, j int) bool {
-		if ns := resources[i].GetNamespace(); ns != resources[j].GetNamespace() {
-			return ns < resources[j].GetNamespace()
-		}
-		return resources[i].GetName() < resources[j].GetName()
-	})
+	page := t.paginator.SortAndPaginate(resources, params.Offset, params.Limit)
 
-	total := int64(len(resources))
-
-	// window the results in-memory: [offset, offset+limit)
-	start := min(offset, total)
-	end := min(offset+limit, total)
-	resources = resources[start:end]
-
-	hasMore := offset+limit < total
+	filterSuffix := ""
+	if params.JSONPath != "" {
+		filterSuffix = " matching the JSONPath filter"
+	}
 
 	var mcpResponse string
-	if hasMore || offset > 0 {
-		filterSuffix := ""
-		if params.JSONPath != "" {
-			filterSuffix = " matching the JSONPath filter"
-		}
-		note := fmt.Sprintf("Returned %d resources (offset %d, limit %d) out of %d total%s. "+
-			"Use a namespace or label selector to narrow results, or increase the limit.",
-			len(resources), offset, limit, total, filterSuffix)
-		if hasMore {
-			note += fmt.Sprintf(" To get the next page, set offset=%d.", offset+limit)
-		}
-		mcpResponse, err = response.CreateMcpResponse(resources, params.Cluster, note)
+	if note := t.paginator.BuildNote(page, filterSuffix); note != "" {
+		mcpResponse, err = response.CreateMcpResponse(page.Items, params.Cluster, note)
 	} else {
-		mcpResponse, err = response.CreateMcpResponse(resources, params.Cluster)
+		mcpResponse, err = response.CreateMcpResponse(page.Items, params.Cluster)
 	}
 	if err != nil {
 		zap.L().Error("failed to create mcp response", zap.String("tool", "listKubernetesResource"), zap.Error(err))

--- a/pkg/toolsets/core/list_resources.go
+++ b/pkg/toolsets/core/list_resources.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
@@ -20,8 +21,8 @@ type listKubernetesResourcesParams struct {
 	Namespace     string `json:"namespace" jsonschema:"the namespace where the resources are located. It must be empty for all namespaces or cluster-wide resources"`
 	Kind          string `json:"kind" jsonschema:"the type of Kubernetes resource (e.g., Pod, Deployment, Service)"`
 	Cluster       string `json:"cluster" jsonschema:"the name of the Kubernetes cluster"`
-	Limit         int64  `json:"limit,omitempty" jsonschema:"maximum number of resources to return, defaults to 10"`
-	Offset        int64  `json:"offset,omitempty" jsonschema:"number of resources to skip before returning results, defaults to 0. Used with limit for pagination"`
+	Limit         int64  `json:"limit,omitempty" jsonschema:"maximum number of resources to return, defaults to 10. Do not change this value unless the user explicitly asks for a different page size or wants to see all the remaining results"`
+	Offset        int64  `json:"offset,omitempty" jsonschema:"how many resources to skip from the start of the full list before returning results. Defaults to 0 (start at the first resource). Use it together with limit to page through results: set offset=0 for the first page, then increase offset by limit for each next page. For example, with limit=10: offset=0 returns resources 1-10, offset=10 returns resources 11-20, offset=20 returns resources 21-30. When more resources are available, the response tells you the exact offset to use for the next page"`
 	LabelSelector string `json:"labelSelector,omitempty" jsonschema:"optional label selector to filter resources (e.g. app=nginx)"`
 	JSONPath      string `json:"jsonPath,omitempty" jsonschema:"optional JSONPath filter predicate to select matching resources. Use @ to reference a resource, e.g. @.status.phase==\"Running\" or @.metadata.labels.app==\"nginx\". Only resources matching the predicate are returned"`
 }
@@ -58,6 +59,15 @@ func (t *Tools) listKubernetesResources(ctx context.Context, toolReq *mcp.CallTo
 			return nil, nil, err
 		}
 	}
+
+	// The order of resources returned by the API is not guaranteed to be stable
+	// across calls, so sort by namespace/name to make offset pagination deterministic.
+	sort.Slice(resources, func(i, j int) bool {
+		if ns := resources[i].GetNamespace(); ns != resources[j].GetNamespace() {
+			return ns < resources[j].GetNamespace()
+		}
+		return resources[i].GetName() < resources[j].GetName()
+	})
 
 	total := int64(len(resources))
 

--- a/pkg/toolsets/core/list_resources_test.go
+++ b/pkg/toolsets/core/list_resources_test.go
@@ -72,6 +72,41 @@ var fakePod3 = &corev1.Pod{
 	},
 }
 
+// pods used to verify sort ordering. They are intentionally declared out of
+// namespace/name order.
+var fakePodBravo = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod-1",
+		Namespace: "bravo",
+	},
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+	},
+	Status: corev1.PodStatus{Phase: corev1.PodRunning},
+}
+
+var fakePodAlphaB = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod-2",
+		Namespace: "alpha",
+	},
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "redis", Image: "redis:latest"}},
+	},
+	Status: corev1.PodStatus{Phase: corev1.PodRunning},
+}
+
+var fakePodAlphaA = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod-1",
+		Namespace: "alpha",
+	},
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "busybox", Image: "busybox:latest"}},
+	},
+	Status: corev1.PodStatus{Phase: corev1.PodRunning},
+}
+
 func listResourcesScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
@@ -280,6 +315,59 @@ func TestListKubernetesResources(t *testing.T) {
 			}, fakePod1, fakePod2),
 			requestURL:    fakeUrl,
 			expectedError: "invalid jsonPath filter",
+		},
+		"list pods - sorted by namespace then name": {
+			params: listKubernetesResourcesParams{
+				Kind:    "pod",
+				Cluster: "local",
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePodBravo, fakePodAlphaB, fakePodAlphaA),
+			requestURL: fakeUrl,
+			expectedResult: `{
+				"llm": [
+					{
+						"metadata": {"name": "pod-1", "namespace": "alpha"},
+						"spec": {"containers": [{"image": "busybox:latest", "name": "busybox", "resources": {}}]},
+						"status": {"phase": "Running"}
+					},
+					{
+						"metadata": {"name": "pod-2", "namespace": "alpha"},
+						"spec": {"containers": [{"image": "redis:latest", "name": "redis", "resources": {}}]},
+						"status": {"phase": "Running"}
+					},
+					{
+						"metadata": {"name": "pod-1", "namespace": "bravo"},
+						"spec": {"containers": [{"image": "nginx:latest", "name": "nginx", "resources": {}}]},
+						"status": {"phase": "Running"}
+					}
+				]
+			}`,
+		},
+		"list pods - sorted ordering respected with paging": {
+			params: listKubernetesResourcesParams{
+				Kind:    "pod",
+				Cluster: "local",
+				Limit:   1,
+				Offset:  1,
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePodBravo, fakePodAlphaB, fakePodAlphaA),
+			requestURL: fakeUrl,
+			expectedResult: `{
+				"llm": {
+					"resources": [
+						{
+							"metadata": {"name": "pod-2", "namespace": "alpha"},
+							"spec": {"containers": [{"image": "redis:latest", "name": "redis", "resources": {}}]},
+							"status": {"phase": "Running"}
+						}
+					],
+					"note": "Returned 1 resources (offset 1, limit 1) out of 3 total. Use a namespace or label selector to narrow results, or increase the limit. To get the next page, set offset=2."
+				}
+			}`,
 		},
 	}
 

--- a/pkg/toolsets/core/list_resources_test.go
+++ b/pkg/toolsets/core/list_resources_test.go
@@ -54,6 +54,24 @@ var fakePod2 = &corev1.Pod{
 	},
 }
 
+var fakePod3 = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "pod-3",
+		Namespace: "default",
+	},
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "busybox",
+				Image: "busybox:latest",
+			},
+		},
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+	},
+}
+
 func listResourcesScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
@@ -156,9 +174,112 @@ func TestListKubernetesResources(t *testing.T) {
 							"status": {"phase": "Running"}
 						}
 					],
-					"note": "Results were limited to 1 items out of 2 total. There may be more resources matching the query. Use a namespace or label selector to narrow results, or increase the limit."
+					"note": "Returned 1 resources (offset 0, limit 1) out of 2 total. Use a namespace or label selector to narrow results, or increase the limit. To get the next page, set offset=1."
 				}
 			}`,
+		},
+		"list pods - with offset paging": {
+			params: listKubernetesResourcesParams{
+				Kind:      "pod",
+				Namespace: "default",
+				Cluster:   "local",
+				Limit:     1,
+				Offset:    1,
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePod1, fakePod2),
+			requestURL: fakeUrl,
+			expectedResult: `{
+				"llm": {
+					"resources": [
+						{
+							"metadata": {"name": "pod-2", "namespace": "default"},
+							"spec": {"containers": [{"image": "redis:latest", "name": "redis", "resources": {}}]},
+							"status": {"phase": "Running"}
+						}
+					],
+					"note": "Returned 1 resources (offset 1, limit 1) out of 2 total. Use a namespace or label selector to narrow results, or increase the limit."
+				}
+			}`,
+		},
+		"list pods - with jsonpath filter": {
+			params: listKubernetesResourcesParams{
+				Kind:      "pod",
+				Namespace: "default",
+				Cluster:   "local",
+				JSONPath:  `@.status.phase=="Pending"`,
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePod1, fakePod2, fakePod3),
+			requestURL: fakeUrl,
+			expectedResult: `{
+				"llm": [
+					{
+						"metadata": {"name": "pod-3", "namespace": "default"},
+						"spec": {"containers": [{"image": "busybox:latest", "name": "busybox", "resources": {}}]},
+						"status": {"phase": "Pending"}
+					}
+				]
+			}`,
+		},
+		"list pods - jsonpath filter combined with paging": {
+			params: listKubernetesResourcesParams{
+				Kind:      "pod",
+				Namespace: "default",
+				Cluster:   "local",
+				JSONPath:  `@.status.phase=="Running"`,
+				Limit:     1,
+				Offset:    1,
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePod1, fakePod2, fakePod3),
+			requestURL: fakeUrl,
+			expectedResult: `{
+				"llm": {
+					"resources": [
+						{
+							"metadata": {"name": "pod-2", "namespace": "default"},
+							"spec": {"containers": [{"image": "redis:latest", "name": "redis", "resources": {}}]},
+							"status": {"phase": "Running"}
+						}
+					],
+					"note": "Returned 1 resources (offset 1, limit 1) out of 2 total matching the JSONPath filter. Use a namespace or label selector to narrow results, or increase the limit."
+				}
+			}`,
+		},
+		"list pods - offset beyond total": {
+			params: listKubernetesResourcesParams{
+				Kind:      "pod",
+				Namespace: "default",
+				Cluster:   "local",
+				Offset:    10,
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePod1, fakePod2),
+			requestURL: fakeUrl,
+			expectedResult: `{
+				"llm": {
+					"resources": "no resources found",
+					"note": "Returned 0 resources (offset 10, limit 10) out of 2 total. Use a namespace or label selector to narrow results, or increase the limit."
+				}
+			}`,
+		},
+		"list pods - invalid jsonpath": {
+			params: listKubernetesResourcesParams{
+				Kind:      "pod",
+				Namespace: "default",
+				Cluster:   "local",
+				JSONPath:  `@.status.phase==`,
+			},
+			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(listResourcesScheme(), map[schema.GroupVersionResource]string{
+				{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+			}, fakePod1, fakePod2),
+			requestURL:    fakeUrl,
+			expectedError: "invalid jsonPath filter",
 		},
 	}
 

--- a/pkg/toolsets/core/list_resources_test.go
+++ b/pkg/toolsets/core/list_resources_test.go
@@ -299,7 +299,7 @@ func TestListKubernetesResources(t *testing.T) {
 			expectedResult: `{
 				"llm": {
 					"resources": "no resources found",
-					"note": "Returned 0 resources (offset 10, limit 10) out of 2 total. Use a namespace or label selector to narrow results, or increase the limit."
+					"note": "Returned 0 resources (offset 10, limit 100) out of 2 total. Use a namespace or label selector to narrow results, or increase the limit."
 				}
 			}`,
 		},

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -56,7 +56,11 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		Meta: map[string]any{
 			toolsSetAnn: toolsSet,
 		},
-		Description: `Returns a list of Kubernetes resources. The namespace must be empty for all namespaces or cluster-wide resources. Supports offset/limit pagination and an optional JSONPath predicate to filter which resources are returned.`},
+		Description: `Returns a list of Kubernetes resources. The namespace must be empty for all namespaces or cluster-wide resources. Supports an optional JSONPath predicate to filter which resources are returned.
+
+Results are paginated with limit (page size, default 10) and offset (how many resources to skip from the start, default 0). To page through results, keep limit the same and increase offset by limit each time: offset=0 is the first page, offset=10 is the second page, offset=20 is the third page, and so on (with limit=10). When more resources remain, the response includes the exact offset value to pass in for the next page.
+
+IMPORTANT: Always display the current page of results to the user before fetching the next page. Never call this tool multiple times in a row without first showing the results and asking the user whether they want to continue to the next page.`},
 		t.listKubernetesResources,
 	)
 

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -56,7 +56,7 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		Meta: map[string]any{
 			toolsSetAnn: toolsSet,
 		},
-		Description: `Returns a list of Kubernetes resources. The namespace must be empty for all namespaces or cluster-wide resources.`},
+		Description: `Returns a list of Kubernetes resources. The namespace must be empty for all namespaces or cluster-wide resources. Supports offset/limit pagination and an optional JSONPath predicate to filter which resources are returned.`},
 		t.listKubernetesResources,
 	)
 

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -6,6 +6,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/core/projects"
+	"github.com/rancher/rancher-ai-mcp/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -27,15 +28,17 @@ type toolsClient interface {
 
 // Tools contains all tools for the MCP server
 type Tools struct {
-	client   toolsClient
-	ReadOnly bool
+	client    toolsClient
+	paginator utils.Paginator
+	ReadOnly  bool
 }
 
 // NewTools creates and returns a new Tools instance.
 func NewTools(client toolsClient, readOnly bool) *Tools {
 	return &Tools{
-		client:   client,
-		ReadOnly: readOnly,
+		client:    client,
+		paginator: utils.NewResourcePaginator(),
+		ReadOnly:  readOnly,
 	}
 }
 
@@ -58,9 +61,7 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 		},
 		Description: `Returns a list of Kubernetes resources. The namespace must be empty for all namespaces or cluster-wide resources. Supports an optional JSONPath predicate to filter which resources are returned.
 
-Results are paginated with limit (page size, default 10) and offset (how many resources to skip from the start, default 0). To page through results, keep limit the same and increase offset by limit each time: offset=0 is the first page, offset=10 is the second page, offset=20 is the third page, and so on (with limit=10). When more resources remain, the response includes the exact offset value to pass in for the next page.
-
-IMPORTANT: Always display the current page of results to the user before fetching the next page. Never call this tool multiple times in a row without first showing the results and asking the user whether they want to continue to the next page.`},
+Results are paginated with limit (page size, default 100) and offset (how many resources to skip from the start, default 0). To page through results, keep limit the same and increase offset by limit each time: offset=0 is the first page, offset=100 is the second page, offset=200 is the third page, and so on (with limit=100). When more resources remain, the response includes the exact offset value to pass in for the next page.`},
 		t.listKubernetesResources,
 	)
 

--- a/pkg/utils/pagination.go
+++ b/pkg/utils/pagination.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const defaultListLimit int64 = 100
+
+// PaginationResult holds the windowed items and pagination metadata.
+type PaginationResult struct {
+	Items   []*unstructured.Unstructured
+	Total   int64
+	Offset  int64
+	Limit   int64
+	HasMore bool
+}
+
+// Paginator sorts and paginates a slice of unstructured Kubernetes resources.
+type Paginator interface {
+	SortAndPaginate(resources []*unstructured.Unstructured, offset, limit int64) PaginationResult
+	BuildNote(result PaginationResult, filterSuffix string) string
+}
+
+// ResourcePaginator implements Paginator for Kubernetes unstructured resources.
+type ResourcePaginator struct{}
+
+// NewResourcePaginator returns a new ResourcePaginator.
+func NewResourcePaginator() *ResourcePaginator {
+	return &ResourcePaginator{}
+}
+
+// SortAndPaginate sorts resources by namespace/name and returns the requested
+// offset/limit window. Limit <= 0 defaults to DefaultListLimit; negative
+// offset is clamped to 0.
+func (p *ResourcePaginator) SortAndPaginate(resources []*unstructured.Unstructured, offset, limit int64) PaginationResult {
+	if limit <= 0 {
+		limit = defaultListLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	sort.Slice(resources, func(i, j int) bool {
+		if ns := resources[i].GetNamespace(); ns != resources[j].GetNamespace() {
+			return ns < resources[j].GetNamespace()
+		}
+		return resources[i].GetName() < resources[j].GetName()
+	})
+
+	total := int64(len(resources))
+	start := min(offset, total)
+	end := min(offset+limit, total)
+
+	return PaginationResult{
+		Items:   resources[start:end],
+		Total:   total,
+		Offset:  offset,
+		Limit:   limit,
+		HasMore: offset+limit < total,
+	}
+}
+
+// BuildNote returns a human-readable pagination note. It returns an empty
+// string when there is no pagination context (single page, offset 0).
+func (p *ResourcePaginator) BuildNote(result PaginationResult, filterSuffix string) string {
+	if !result.HasMore && result.Offset == 0 {
+		return ""
+	}
+
+	note := fmt.Sprintf("Returned %d resources (offset %d, limit %d) out of %d total%s. "+
+		"Use a namespace or label selector to narrow results, or increase the limit.",
+		len(result.Items), result.Offset, result.Limit, result.Total, filterSuffix)
+	if result.HasMore {
+		note += fmt.Sprintf(" To get the next page, set offset=%d.", result.Offset+result.Limit)
+	}
+
+	return note
+}

--- a/pkg/utils/pagination_test.go
+++ b/pkg/utils/pagination_test.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makePod(name, namespace string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	return u
+}
+
+func TestSortAndPaginate(t *testing.T) {
+	p := NewResourcePaginator()
+
+	tests := map[string]struct {
+		resources     []*unstructured.Unstructured
+		offset        int64
+		limit         int64
+		expectedNames []string
+		expectedTotal int64
+		hasMore       bool
+		resultOffset  int64
+		resultLimit   int64
+	}{
+		"default limit when limit is 0": {
+			resources:     []*unstructured.Unstructured{makePod("a", "ns")},
+			offset:        0,
+			limit:         0,
+			expectedNames: []string{"a"},
+			expectedTotal: 1,
+			hasMore:       false,
+			resultOffset:  0,
+			resultLimit:   defaultListLimit,
+		},
+		"negative offset clamped to 0": {
+			resources:     []*unstructured.Unstructured{makePod("a", "ns")},
+			offset:        -5,
+			limit:         10,
+			expectedNames: []string{"a"},
+			expectedTotal: 1,
+			hasMore:       false,
+			resultOffset:  0,
+			resultLimit:   10,
+		},
+		"first page with hasMore": {
+			resources: []*unstructured.Unstructured{
+				makePod("c", "ns"),
+				makePod("a", "ns"),
+				makePod("b", "ns"),
+			},
+			offset:        0,
+			limit:         2,
+			expectedNames: []string{"a", "b"},
+			expectedTotal: 3,
+			hasMore:       true,
+			resultOffset:  0,
+			resultLimit:   2,
+		},
+		"second page no hasMore": {
+			resources: []*unstructured.Unstructured{
+				makePod("c", "ns"),
+				makePod("a", "ns"),
+				makePod("b", "ns"),
+			},
+			offset:        2,
+			limit:         2,
+			expectedNames: []string{"c"},
+			expectedTotal: 3,
+			hasMore:       false,
+			resultOffset:  2,
+			resultLimit:   2,
+		},
+		"offset beyond total": {
+			resources: []*unstructured.Unstructured{
+				makePod("a", "ns"),
+				makePod("b", "ns"),
+			},
+			offset:        10,
+			limit:         5,
+			expectedNames: []string{},
+			expectedTotal: 2,
+			hasMore:       false,
+			resultOffset:  10,
+			resultLimit:   5,
+		},
+		"sorted by namespace then name": {
+			resources: []*unstructured.Unstructured{
+				makePod("pod-1", "bravo"),
+				makePod("pod-2", "alpha"),
+				makePod("pod-1", "alpha"),
+			},
+			offset:        0,
+			limit:         10,
+			expectedNames: []string{"pod-1", "pod-2", "pod-1"},
+			expectedTotal: 3,
+			hasMore:       false,
+			resultOffset:  0,
+			resultLimit:   10,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := p.SortAndPaginate(tt.resources, tt.offset, tt.limit)
+
+			names := make([]string, len(result.Items))
+			for i, item := range result.Items {
+				names[i] = item.GetName()
+			}
+
+			assert.Equal(t, tt.expectedNames, names)
+			assert.Equal(t, tt.expectedTotal, result.Total)
+			assert.Equal(t, tt.hasMore, result.HasMore)
+			assert.Equal(t, tt.resultOffset, result.Offset)
+			assert.Equal(t, tt.resultLimit, result.Limit)
+		})
+	}
+}
+
+func TestBuildNote(t *testing.T) {
+	p := NewResourcePaginator()
+
+	tests := map[string]struct {
+		result       PaginationResult
+		filterSuffix string
+		expected     string
+	}{
+		"empty when no pagination context": {
+			result: PaginationResult{
+				Items:   []*unstructured.Unstructured{makePod("a", "ns")},
+				Total:   1,
+				Offset:  0,
+				Limit:   10,
+				HasMore: false,
+			},
+			expected: "",
+		},
+		"includes next page when hasMore": {
+			result: PaginationResult{
+				Items:   []*unstructured.Unstructured{makePod("a", "ns")},
+				Total:   3,
+				Offset:  0,
+				Limit:   1,
+				HasMore: true,
+			},
+			expected: "Returned 1 resources (offset 0, limit 1) out of 3 total. " +
+				"Use a namespace or label selector to narrow results, or increase the limit. " +
+				"To get the next page, set offset=1.",
+		},
+		"no next page hint on last page with offset": {
+			result: PaginationResult{
+				Items:   []*unstructured.Unstructured{makePod("a", "ns")},
+				Total:   2,
+				Offset:  1,
+				Limit:   1,
+				HasMore: false,
+			},
+			expected: "Returned 1 resources (offset 1, limit 1) out of 2 total. " +
+				"Use a namespace or label selector to narrow results, or increase the limit.",
+		},
+		"includes filterSuffix": {
+			result: PaginationResult{
+				Items:   []*unstructured.Unstructured{makePod("a", "ns")},
+				Total:   3,
+				Offset:  0,
+				Limit:   1,
+				HasMore: true,
+			},
+			filterSuffix: " matching the JSONPath filter",
+			expected: "Returned 1 resources (offset 0, limit 1) out of 3 total matching the JSONPath filter. " +
+				"Use a namespace or label selector to narrow results, or increase the limit. " +
+				"To get the next page, set offset=1.",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			note := p.BuildNote(tt.result, tt.filterSuffix)
+			assert.Equal(t, tt.expected, note)
+		})
+	}
+}


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-mcp/issues/44

## Problem
`listKubernetesResources` returned all matching resources in a single response. For resource types with many instances (e.g. `Pods`, `Secrets`), this produced large payloads that consumed excessive LLM context and could reach the max token limit or degrade response quality. There was also no way to filter forcing the LLM to scan everything. 

## Solution
- Pagination: Added `limit` and `offset` parameters for page-based result windowing. When more results exist, the response includes the exact offset for the next page. 

- JSONPath filtering: Added a `jsonPath` parameter that accepts a predicate expression (e.g. @.status.phase=="Running") to filter resources before pagination, reducing noise at the source.