### PR TITLE
replace nested resource object with typed manifest string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	k8s.io/metrics v0.36.2
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -191,5 +192,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/toolsets/core/create_resource.go
+++ b/pkg/toolsets/core/create_resource.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 // createKubernetesResourceParams defines the structure for creating a general Kubernetes resource.
@@ -21,7 +21,7 @@ type createKubernetesResourceParams struct {
 	Namespace string `json:"namespace,omitempty" jsonschema:"the namespace where the resource is located. It must be empty for cluster-wide resources"`
 	Kind      string `json:"kind" jsonschema:"the type of Kubernetes resource (e.g., Pod, Deployment, Service)"`
 	Cluster   string `json:"cluster" jsonschema:"the name of the Kubernetes cluster"`
-	Resource  any    `json:"resource" jsonschema:"the resource to be created. This must be a JSON object"`
+	Manifest  string `json:"manifest" jsonschema:"the resource to create as a complete Kubernetes manifest, in YAML or JSON (e.g. \"apiVersion: v1\\nkind: ConfigMap\\nmetadata:\\n  name: my-cm\")"`
 }
 
 // createKubernetesResource creates a new Kubernetes resource.
@@ -35,16 +35,10 @@ func (t *Tools) createKubernetesResource(ctx context.Context, toolReq *mcp.CallT
 		return nil, nil, err
 	}
 
-	objBytes, err := json.Marshal(params.Resource)
-	if err != nil {
-		zap.L().Error("failed to marshal resource", zap.String("tool", "createKubernetesResource"), zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to marshal resource: %w", err)
-	}
-
 	unstructuredObj := &unstructured.Unstructured{}
-	if err := json.Unmarshal(objBytes, unstructuredObj); err != nil {
-		zap.L().Error("failed to create unstructured resource", zap.String("tool", "createKubernetesResource"), zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to create unstructured object: %w", err)
+	if err := yaml.Unmarshal([]byte(params.Manifest), unstructuredObj); err != nil {
+		zap.L().Error("failed to parse manifest", zap.String("tool", "createKubernetesResource"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to parse manifest (expected YAML or JSON): %w", err)
 	}
 
 	obj, err := resourceInterface.Create(ctx, unstructuredObj, metav1.CreateOptions{})

--- a/pkg/toolsets/core/create_resource_plan.go
+++ b/pkg/toolsets/core/create_resource_plan.go
@@ -2,13 +2,13 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/pkg/response"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 // createKubernetesResourcePlan plans the creation of a new Kubernetes resource.
@@ -16,16 +16,10 @@ import (
 func (t *Tools) createKubernetesResourcePlan(_ context.Context, _ *mcp.CallToolRequest, params createKubernetesResourceParams) (*mcp.CallToolResult, any, error) {
 	zap.L().Debug("createKubernetesResource_plan called")
 
-	objBytes, err := json.Marshal(params.Resource)
-	if err != nil {
-		zap.L().Error("failed to marshal resource", zap.String("tool", "createKubernetesResource_plan"), zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to marshal resource: %w", err)
-	}
-
 	unstructuredObj := &unstructured.Unstructured{}
-	if err := json.Unmarshal(objBytes, unstructuredObj); err != nil {
-		zap.L().Error("failed to create unstructured resource", zap.String("tool", "createKubernetesResource_plan"), zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to create unstructured object: %w", err)
+	if err := yaml.Unmarshal([]byte(params.Manifest), unstructuredObj); err != nil {
+		zap.L().Error("failed to parse manifest", zap.String("tool", "createKubernetesResource_plan"), zap.Error(err))
+		return nil, nil, fmt.Errorf("failed to parse manifest (expected YAML or JSON): %w", err)
 	}
 
 	createResource := response.NewCreateResourceInput(unstructuredObj, params.Cluster)

--- a/pkg/toolsets/core/create_resource_plan_test.go
+++ b/pkg/toolsets/core/create_resource_plan_test.go
@@ -9,31 +9,34 @@ import (
 )
 
 func TestCreateKubernetesResourcePlan(t *testing.T) {
-	configMapResource := map[string]interface{}{
+	configMapYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key1: value1
+  key2: value2`
+
+	configMapJSON := `{
 		"apiVersion": "v1",
-		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
-			"name":      "test-config",
-			"namespace": "default",
-		},
-		"data": map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-		},
-	}
+		"kind": "ConfigMap",
+		"metadata": {"name": "test-config", "namespace": "default"},
+		"data": {"key1": "value1", "key2": "value2"}
+	}`
 
 	tests := map[string]struct {
 		params         createKubernetesResourceParams
 		expectedResult string
 		expectedError  string
 	}{
-		"create configmap plan": {
+		"create configmap plan from YAML": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  configMapResource,
+				Manifest:  configMapYAML,
 			},
 			expectedResult: `[{
 				"type": "create",
@@ -51,25 +54,49 @@ func TestCreateKubernetesResourcePlan(t *testing.T) {
 				}
 			}]`,
 		},
-		"create plan - marshal error": {
+		"create configmap plan from JSON": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  make(chan int),
+				Manifest:  configMapJSON,
 			},
-			expectedError: "failed to marshal resource",
+			expectedResult: `[{
+				"type": "create",
+				"payload": {
+					"apiVersion": "v1",
+					"kind": "ConfigMap",
+					"metadata": {"name": "test-config", "namespace": "default"},
+					"data": {"key1": "value1", "key2": "value2"}
+				},
+				"resource": {
+					"name": "test-config",
+					"kind": "ConfigMap",
+					"cluster": "local",
+					"namespace": "default"
+				}
+			}]`,
 		},
-		"create plan - invalid resource": {
+		"create plan - malformed manifest": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  "invalid-resource-type",
+				Manifest:  "foo: [bar",
 			},
-			expectedError: "failed to create unstructured object",
+			expectedError: "failed to parse manifest",
+		},
+		"create plan - not an object": {
+			params: createKubernetesResourceParams{
+				Name:      "test-config",
+				Namespace: "default",
+				Kind:      "configmap",
+				Cluster:   "local",
+				Manifest:  "invalid-resource-type",
+			},
+			expectedError: "failed to parse manifest",
 		},
 	}
 

--- a/pkg/toolsets/core/create_resource_test.go
+++ b/pkg/toolsets/core/create_resource_test.go
@@ -27,18 +27,21 @@ func TestCreateKubernetesResource(t *testing.T) {
 	fakeUrl := "https://localhost:8080"
 	fakeToken := "fakeToken"
 
-	configMapResource := map[string]interface{}{
+	configMapYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key1: value1
+  key2: value2`
+
+	configMapJSON := `{
 		"apiVersion": "v1",
-		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
-			"name":      "test-config",
-			"namespace": "default",
-		},
-		"data": map[string]interface{}{
-			"key1": "value1",
-			"key2": "value2",
-		},
-	}
+		"kind": "ConfigMap",
+		"metadata": {"name": "test-config", "namespace": "default"},
+		"data": {"key1": "value1", "key2": "value2"}
+	}`
 
 	tests := map[string]struct {
 		params        createKubernetesResourceParams
@@ -51,13 +54,13 @@ func TestCreateKubernetesResource(t *testing.T) {
 		expectedResult string
 		expectedError  string
 	}{
-		"create configmap": {
+		"create configmap from YAML": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  configMapResource,
+				Manifest:  configMapYAML,
 			},
 			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(createResourceScheme(), map[schema.GroupVersionResource]string{
@@ -77,13 +80,13 @@ func TestCreateKubernetesResource(t *testing.T) {
 				]
 			}`,
 		},
-		"create configmap when tool is configured with URL": {
+		"create configmap from JSON when tool is configured with URL": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  configMapResource,
+				Manifest:  configMapJSON,
 			},
 			rancherURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(createResourceScheme(), map[schema.GroupVersionResource]string{
@@ -104,31 +107,31 @@ func TestCreateKubernetesResource(t *testing.T) {
 			}`,
 		},
 
-		"create configmap - marshal error": {
+		"create configmap - malformed manifest": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  make(chan int),
+				Manifest:  "foo: [bar",
 			},
 			requestURL:    fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClient(createResourceScheme()),
-			expectedError: `failed to marshal resource`,
+			expectedError: `failed to parse manifest`,
 		},
-		"create configmap - invalid": {
+		"create configmap - not an object": {
 			params: createKubernetesResourceParams{
 				Name:      "test-config",
 				Namespace: "default",
 				Kind:      "configmap",
 				Cluster:   "local",
-				Resource:  "invalid-resource-type",
+				Manifest:  "invalid-resource-type",
 			},
 			requestURL: fakeUrl,
 			fakeDynClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(createResourceScheme(), map[schema.GroupVersionResource]string{
 				{Group: "", Version: "v1", Resource: "configmaps"}: "ConfigMapList",
 			}),
-			expectedError: "failed to create unstructured object",
+			expectedError: "failed to parse manifest",
 		},
 	}
 

--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -119,7 +119,15 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 			Meta: map[string]any{
 				toolsSetAnn: toolsSet,
 			},
-			Description: `Creates a resource in a Kubernetes cluster. The namespace must be empty for cluster-wide resources.`},
+			Description: `Creates a resource in a Kubernetes cluster from a complete Kubernetes manifest passed in the 'manifest' field, in YAML or JSON. The namespace must be empty for cluster-wide resources.
+
+Example of the manifest parameter (YAML):
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+data:
+  key: value`},
 			t.createKubernetesResource,
 		)
 
@@ -128,7 +136,7 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 			Meta: map[string]any{
 				toolsSetAnn: toolsSet,
 			},
-			Description: `Plans to create a resource in a Kubernetes cluster. It returns the JSON representation of the resource to be created without actually creating it in the cluster. Only used for displaying the resource when using human validation. The namespace must be empty for cluster-wide resources.`},
+			Description: `Plans to create a resource in a Kubernetes cluster from a complete Kubernetes manifest passed in the 'manifest' field, in YAML or JSON. It returns the JSON representation of the resource to be created without actually creating it in the cluster. Only used for displaying the resource when using human validation. The namespace must be empty for cluster-wide resources.`},
 			t.createKubernetesResourcePlan)
 
 		mcp.AddTool(mcpServer, &mcp.Tool{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher-ai-agent/issues/147

## Problem
Smaller or local models (e.g. `gpt-oss:20b`) struggle to emit deeply nested JSON objects, causing the `createResource` tool call to fail. 

## Fix
- Replaced the nested any object with a typed string field (manifest).

- Used `sigs.k8s.io/yaml.Unmarshal` to parse the input. Works seamlessly with both JSON and standard Kubernetes YAML (since YAML is a superset of JSON and unmarshals cleanly into unstructured.Unstructured). This lets models emit the k8s YAML they are heavily trained on.