### PR TITLE
Explicitly prevent scaling of the local cluster

### DIFF
--- a/pkg/toolsets/provisioning/analyze_cluster.go
+++ b/pkg/toolsets/provisioning/analyze_cluster.go
@@ -26,7 +26,7 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 	if ns == "" {
 		ns = DefaultClusterResourcesNamespace
 		if params.Cluster == LocalCluster {
-			ns = "fleet-local"
+			ns = LocalClusterResourcesNamespace
 		}
 	}
 
@@ -37,7 +37,7 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 
 	log.Debug("Analyzing cluster")
 
-	provClusterResource, provCluster, err := t.getProvisioningCluster(ctx, toolReq, log, ns, params.Cluster)
+	provClusterResource, provCluster, err := t.getProvisioningCluster(ctx, log, ns, params.Cluster)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.Error("failed to get provisioning cluster", zap.Error(err))
 		return nil, nil, err
@@ -107,7 +107,7 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 
 	// get all machine configs for node driver clusters.
 	log.Debug("fetching machine pool configs")
-	machineConfigs, err := t.getMachinePoolConfigs(ctx, toolReq, log, provCluster)
+	machineConfigs, err := t.getMachinePoolConfigs(ctx, log, provCluster)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.Error("failed to get machine pool configs", zap.Error(err))
 		return nil, nil, err
@@ -122,7 +122,7 @@ func (t *Tools) analyzeCluster(ctx context.Context, toolReq *mcp.CallToolRequest
 
 	// get all the CAPI machine resources
 	log.Debug("fetching CAPI machine resources")
-	machines, machineSets, machineDeployments, err := t.getAllCAPIMachineResources(ctx, toolReq, log, getCAPIMachineResourcesParams{
+	machines, machineSets, machineDeployments, err := t.getAllCAPIMachineResources(ctx, log, getCAPIMachineResourcesParams{
 		namespace:     DefaultClusterResourcesNamespace,
 		targetCluster: params.Cluster,
 	})

--- a/pkg/toolsets/provisioning/analyze_cluster_machines.go
+++ b/pkg/toolsets/provisioning/analyze_cluster_machines.go
@@ -29,7 +29,7 @@ func (t *Tools) analyzeClusterMachines(ctx context.Context, toolReq *mcp.CallToo
 	})
 	log.Info("Analyzing Cluster Machines")
 
-	machines, machineSets, machineDeployments, err := t.getAllCAPIMachineResources(ctx, toolReq, log, getCAPIMachineResourcesParams{
+	machines, machineSets, machineDeployments, err := t.getAllCAPIMachineResources(ctx, log, getCAPIMachineResourcesParams{
 		namespace:     ns,
 		targetCluster: params.Cluster,
 	})

--- a/pkg/toolsets/provisioning/get_cluster_machine.go
+++ b/pkg/toolsets/provisioning/get_cluster_machine.go
@@ -26,7 +26,7 @@ func (t *Tools) getClusterMachine(ctx context.Context, toolReq *mcp.CallToolRequ
 	log.Info("Getting Cluster Machine")
 
 	var resources []*unstructured.Unstructured
-	machine, machineSet, machineDeployment, err := t.getCAPIMachineResourcesByName(ctx, toolReq, log, getCAPIMachineResourcesParams{
+	machine, machineSet, machineDeployment, err := t.getCAPIMachineResourcesByName(ctx, log, getCAPIMachineResourcesParams{
 		namespace:     "fleet-default",
 		targetCluster: params.Cluster,
 		machineName:   params.MachineName,

--- a/pkg/toolsets/provisioning/provisioning_utils.go
+++ b/pkg/toolsets/provisioning/provisioning_utils.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/converter"
@@ -31,6 +30,7 @@ const (
 
 	LocalCluster                     = "local"
 	DefaultClusterResourcesNamespace = "fleet-default"
+	LocalClusterResourcesNamespace   = "fleet-local"
 )
 
 type getCAPIMachineResourcesParams struct {
@@ -39,7 +39,7 @@ type getCAPIMachineResourcesParams struct {
 	machineName   string
 }
 
-func (t *Tools) getCAPIMachineResourcesByName(ctx context.Context, toolReq *mcp.CallToolRequest, log *zap.Logger, params getCAPIMachineResourcesParams) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, error) {
+func (t *Tools) getCAPIMachineResourcesByName(ctx context.Context, log *zap.Logger, params getCAPIMachineResourcesParams) (*unstructured.Unstructured, *unstructured.Unstructured, *unstructured.Unstructured, error) {
 	if params.namespace == "" {
 		params.namespace = DefaultClusterResourcesNamespace
 	}
@@ -165,7 +165,7 @@ func (t *Tools) getCAPIMachineResourcesByName(ctx context.Context, toolReq *mcp.
 }
 
 // getAllCAPIMachineResources retrieves the cluster API machines, machine sets, and machine deployments for a given provisioning cluster.
-func (t *Tools) getAllCAPIMachineResources(ctx context.Context, toolReq *mcp.CallToolRequest, log *zap.Logger, params getCAPIMachineResourcesParams) ([]*unstructured.Unstructured, []*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+func (t *Tools) getAllCAPIMachineResources(ctx context.Context, log *zap.Logger, params getCAPIMachineResourcesParams) ([]*unstructured.Unstructured, []*unstructured.Unstructured, []*unstructured.Unstructured, error) {
 	if params.namespace == "" {
 		params.namespace = DefaultClusterResourcesNamespace
 	}
@@ -278,7 +278,7 @@ func (t *Tools) getAllCAPIMachineResources(ctx context.Context, toolReq *mcp.Cal
 	return capiMachines, capiMachineSets, capiMachineDeployments, nil
 }
 
-func (t *Tools) getProvisioningCluster(ctx context.Context, toolReq *mcp.CallToolRequest, log *zap.Logger, ns, clusterName string) (*unstructured.Unstructured, provisioningV1.Cluster, error) {
+func (t *Tools) getProvisioningCluster(ctx context.Context, log *zap.Logger, ns, clusterName string) (*unstructured.Unstructured, provisioningV1.Cluster, error) {
 	log.Debug("fetching provisioning cluster",
 		zap.String("namespace", ns),
 		zap.String("cluster", clusterName))
@@ -325,7 +325,7 @@ func (t *Tools) getProvisioningCluster(ctx context.Context, toolReq *mcp.CallToo
 	return provisioningClusterResource, provCluster, nil
 }
 
-func (t *Tools) getMachinePoolConfigs(ctx context.Context, toolReq *mcp.CallToolRequest, log *zap.Logger, provCluster provisioningV1.Cluster) ([]*unstructured.Unstructured, error) {
+func (t *Tools) getMachinePoolConfigs(ctx context.Context, log *zap.Logger, provCluster provisioningV1.Cluster) ([]*unstructured.Unstructured, error) {
 	log.Debug("fetching machine pool configs",
 		zap.String("cluster", provCluster.Name))
 

--- a/pkg/toolsets/provisioning/scale_node_pool.go
+++ b/pkg/toolsets/provisioning/scale_node_pool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
@@ -39,6 +40,15 @@ func (t *Tools) scaleClusterNodePool(ctx context.Context, toolReq *mcp.CallToolR
 		"amountToAdd":      strconv.Itoa(params.AmountToAdd),
 		"amountToSubtract": strconv.Itoa(params.AmountToSubtract),
 	})
+
+	// The local cluster can never be scaled as it does not utilize
+	// node pools, it's a special kind of imported cluster. A dedicated
+	// error is returned so the agent knows that this isn't just a
+	// generic problem with the tool.
+	if strings.ToLower(params.Cluster) == "local" {
+		log.Error("scaling is not supported for the local cluster")
+		return nil, nil, fmt.Errorf("scaling node pools in the local cluster is not supported")
+	}
 
 	log.Debug("Scaling cluster node pool")
 

--- a/pkg/toolsets/provisioning/scale_node_pool.go
+++ b/pkg/toolsets/provisioning/scale_node_pool.go
@@ -91,7 +91,7 @@ func (t *Tools) scaleClusterNodePoolPatch(ctx context.Context, toolReq *mcp.Call
 	amountToAdd := int32(params.AmountToAdd)
 	amountToSubtract := int32(params.AmountToSubtract)
 
-	_, provCluster, err := t.getProvisioningCluster(ctx, toolReq, log, params.Namespace, params.Cluster)
+	_, provCluster, err := t.getProvisioningCluster(ctx, log, params.Namespace, params.Cluster)
 	if err != nil {
 		log.Error("failed to get provisioning cluster", zap.Error(err))
 		return nil, err

--- a/pkg/toolsets/provisioning/tools.go
+++ b/pkg/toolsets/provisioning/tools.go
@@ -92,7 +92,8 @@ This should only be used when information about the supported rke2 and k3s is ne
 			},
 			Description: `Changes the size of an existing node pool for an rke2 or k3s cluster.
 This should be used when the user wants to change the size of an existing node pool for an rke2 or k3s cluster.
-Pools cannot be scaled to zero nodes, and etcd node pools cannot be scaled below 3 nodes to prevent loss of quorum.`},
+Pools cannot be scaled to zero nodes, and etcd node pools cannot be scaled below 3 nodes to prevent loss of quorum.
+The local cluster does not support node pool scaling.`},
 			t.scaleClusterNodePool)
 
 		mcp.AddTool(mcpServer, &mcp.Tool{
@@ -102,7 +103,8 @@ Pools cannot be scaled to zero nodes, and etcd node pools cannot be scaled below
 			},
 			Description: `Plans to change the size of an existing node pool for an rke2 or k3s cluster. It returns the JSON representation of the updated node pool resource without actually applying the change in the cluster.
 Only used for displaying the resource when using human validation. This should be used when the user wants to change the size of an existing node pool for an rke2 or k3s cluster.
-Pools cannot be scaled to zero nodes, and etcd node pools cannot be scaled below 3 nodes to prevent loss of quorum.`},
+Pools cannot be scaled to zero nodes, and etcd node pools cannot be scaled below 3 nodes to prevent loss of quorum.
+The local cluster does not support node pool scaling.`},
 			t.scaleClusterNodePoolPlan)
 
 		mcp.AddTool(mcpServer, &mcp.Tool{


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher-ai-mcp/issues/109

Scaling the local cluster isn't supported, it's treated as a special kind of imported cluster. Additionally, it's located in a different namespace than other downstream clusters, `fleet-local`. Currently the scaling tool expects all clusters to be in the `fleet-default` namespace so asking the agent to scale the local cluster will always result in a not found error. 


This PR updates the node pool scaling tool to return a dedicated error when a user attempts to scale the local cluster, and updates the tool description to indicate to the agent that the tool does not support that operation. I've also trimmed down some function signatures to remove an unused parameter. 