### PR TITLE
Add listClusters to provisioning toolset

### DIFF
--- a/pkg/toolsets/core/tools.go
+++ b/pkg/toolsets/core/tools.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/core/projects"
 	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/core/rbac"
+	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/provisioning"
 	"github.com/rancher/rancher-ai-mcp/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -105,7 +106,7 @@ Results are paginated with limit (page size, default 100) and offset (how many r
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "listClusters",
 		Meta: map[string]any{
-			toolsSetAnn: toolsSet,
+			toolsSetAnn: toolsSet + "," + provisioning.ToolsSet,
 		},
 		// InputSchema explicitly includes "properties" to satisfy OpenAI's requirement
 		// that object schemas must have a "properties" field, even when there are no parameters.

--- a/pkg/toolsets/core/tools_test.go
+++ b/pkg/toolsets/core/tools_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/provisioning"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,7 +66,11 @@ func TestAddTools(t *testing.T) {
 	assert.Len(t, toolsResult.Tools, 21, "incorrect number of tools registered")
 	// assert that all tools have the correct toolset annotation
 	for _, tool := range toolsResult.Tools {
-		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+		if tool.Name == "listClusters" {
+			assert.Equal(t, toolsSet+","+provisioning.ToolsSet, tool.Meta[toolsSetAnn])
+		} else {
+			assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+		}
 	}
 }
 
@@ -121,7 +126,11 @@ func TestAddToolsReadOnly(t *testing.T) {
 	toolNames := make(map[string]bool)
 	for _, tool := range toolsResult.Tools {
 		toolNames[tool.Name] = true
-		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+		if tool.Name == "listClusters" {
+			assert.Equal(t, toolsSet+","+provisioning.ToolsSet, tool.Meta[toolsSetAnn])
+		} else {
+			assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+		}
 	}
 	assert.False(t, toolNames["patchKubernetesResource"], "patchKubernetesResource should not be registered in read-only mode")
 	assert.False(t, toolNames["patchKubernetesResourcePlan"], "patchKubernetesResourcePlan should not be registered in read-only mode")

--- a/pkg/toolsets/provisioning/tools.go
+++ b/pkg/toolsets/provisioning/tools.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	toolsSet    = "provisioning"
+	ToolsSet    = "provisioning"
 	toolsSetAnn = "toolset"
 )
 
@@ -43,7 +43,7 @@ func (t *Tools) AddTools(mcpServer *mcp.Server) {
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "analyzeCluster",
 		Meta: map[string]any{
-			toolsSetAnn: toolsSet,
+			toolsSetAnn: ToolsSet,
 		},
 		Description: `Gets a cluster's complete configuration including provisioning and management clusters, the CAPI cluster, CAPI machines, and machine pool configs.
 This should be used when a complete overview of the clusters current state and its configuration is required.`},
@@ -52,7 +52,7 @@ This should be used when a complete overview of the clusters current state and i
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "analyzeClusterMachines",
 		Meta: map[string]any{
-			toolsSetAnn: toolsSet,
+			toolsSetAnn: ToolsSet,
 		},
 		Description: `Gets all Machine related resources for a cluster including Machines, MachineSets, and MachineDeployments.
 This should be used when a summary or overview of just the existing machine resources is required.`},
@@ -61,7 +61,7 @@ This should be used when a summary or overview of just the existing machine reso
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "getClusterMachine",
 		Meta: map[string]any{
-			toolsSetAnn: toolsSet,
+			toolsSetAnn: ToolsSet,
 		},
 		Description: `Gets a specific machine and its parent MachineSet and MachineDeployment.
 This should be used when detailed information about a specific machine is required.`},
@@ -70,7 +70,7 @@ This should be used when detailed information about a specific machine is requir
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "listK3kClusters",
 		Meta: map[string]any{
-			toolsSetAnn: toolsSet,
+			toolsSetAnn: ToolsSet,
 		},
 		Description: `List K3k virtual clusters deployed across downstream clusters.`},
 		t.getK3kClusters)
@@ -78,7 +78,7 @@ This should be used when detailed information about a specific machine is requir
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name: "listSupportedKubernetesVersions",
 		Meta: map[string]any{
-			toolsSetAnn: toolsSet,
+			toolsSetAnn: ToolsSet,
 		},
 		Description: `Returns the currently supported rke2 and k3s versions that can be provisioned.
 This should only be used when information about the supported rke2 and k3s is needed. This is often required to support provisioning custom and imported clusters.`},
@@ -88,7 +88,7 @@ This should only be used when information about the supported rke2 and k3s is ne
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "scaleClusterNodePool",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Changes the size of an existing node pool for an rke2 or k3s cluster.
 This should be used when the user wants to change the size of an existing node pool for an rke2 or k3s cluster.
@@ -99,7 +99,7 @@ The local cluster does not support node pool scaling.`},
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "scaleClusterNodePoolPlan",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Plans to change the size of an existing node pool for an rke2 or k3s cluster. It returns the JSON representation of the updated node pool resource without actually applying the change in the cluster.
 Only used for displaying the resource when using human validation. This should be used when the user wants to change the size of an existing node pool for an rke2 or k3s cluster.
@@ -110,7 +110,7 @@ The local cluster does not support node pool scaling.`},
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "createK3kCluster",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Create a new K3k cluster in a specific downstream cluster.`},
 			t.createK3kCluster)
@@ -118,7 +118,7 @@ The local cluster does not support node pool scaling.`},
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "createK3kClusterPlan",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Plans to create a new K3k cluster in a specific downstream cluster. It returns the JSON representation of the resource to be created without actually creating it. Only used for displaying the resource when using human validation.`},
 			t.createK3kClusterPlan)
@@ -126,7 +126,7 @@ The local cluster does not support node pool scaling.`},
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "createImportedCluster",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Creates an imported cluster within Rancher.
 This should only be used when the user wants to create a new imported cluster. Do not use this tool when the user asks to create a new custom cluster.`},
@@ -135,7 +135,7 @@ This should only be used when the user wants to create a new imported cluster. D
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "createImportedClusterPlan",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Plans to create an imported cluster within Rancher. It returns the JSON representation of the resource to be created without actually creating it in the cluster. Only used for displaying the resource when using human validation.
 This should only be used when the user wants to create a new imported cluster. Do not use this tool when the user asks to create a new custom cluster.`},
@@ -144,7 +144,7 @@ This should only be used when the user wants to create a new imported cluster. D
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "createCustomCluster",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Creates a custom cluster within Rancher.
 This should only be used when the user wants to create a new custom cluster. Do not use this tool if a user asks to create an imported cluster.`},
@@ -153,7 +153,7 @@ This should only be used when the user wants to create a new custom cluster. Do 
 		mcp.AddTool(mcpServer, &mcp.Tool{
 			Name: "createCustomClusterPlan",
 			Meta: map[string]any{
-				toolsSetAnn: toolsSet,
+				toolsSetAnn: ToolsSet,
 			},
 			Description: `Plans to create a custom cluster within Rancher. It returns the JSON representation of the resource to be created without actually creating it in the cluster. Only used for displaying the resource when using human validation.
 This should only be used when the user wants to create a new custom cluster. Do not use this tool if a user asks to create an imported cluster.`},


### PR DESCRIPTION
## Issue https://github.com/rancher/rancher-ai-mcp/issues/68

## Problem
In adaptive mode, Liz attempts to list clusters via the provisioning agent. This currently fails because the listClusters tool resides in the Rancher agent.

## Solution
Add listClusters to the provisioning toolset. We also retain it in the Rancher agent to prevent unnecessary agent hops.

Related to https://github.com/rancher/rancher-ai-agent/pull/335