### PR TITLE
Add support for non-resource URLS to the client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,8 +1,14 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -110,7 +116,7 @@ func (c *Client) CreateClientSet(ctx context.Context, token string, cluster stri
 func (c *Client) GetResourceInterface(ctx context.Context, token string, namespace string, cluster string, gvr schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
 	clusterID, err := c.GetClusterID(ctx, token, cluster)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get cluster ID error: %w", err)
 	}
 	restConfig, err := c.CreateRestConfig(token, clusterID)
 	if err != nil {
@@ -133,7 +139,7 @@ func (c *Client) GetResourceInterface(ctx context.Context, token string, namespa
 func (c *Client) GetResource(ctx context.Context, params GetParams) (*unstructured.Unstructured, error) {
 	resourceInterface, err := c.GetResourceInterface(ctx, params.Token, params.Namespace, params.Cluster, converter.K8sKindsToGVRs[strings.ToLower(params.Kind)])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get resource interface error: %w", err)
 	}
 
 	obj, err := resourceInterface.Get(ctx, params.Name, metav1.GetOptions{})
@@ -410,6 +416,63 @@ func (c *Client) CreateRestConfig(token string, clusterID string) (*rest.Config,
 	return restConfig, nil
 }
 
+// GetRancherURL performs an authenticated HTTP request against rancherURL+path.
+//
+// The request is authenticated using the provided token as Bearer token in the Authorization header.
+// If body is non-nil it is JSON-encoded and sent as the request body.
+// The request is sent using the specified HTTP method (e.g., GET, POST).
+//
+// The response is expected to have a status code of 200 OK.
+//
+// If v is non-nil the response body is assumed to be JSON and unmarshalled into
+// it.
+func (c *Client) GetRancherURL(ctx context.Context, token string, method string, rancherPath string, body any, v any) error {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.insecure, //nolint:gosec
+				RootCAs:            rootCAsFromBundle(c.caBundle),
+			},
+		},
+	}
+
+	requestPath := c.rancherURL + rancherPath
+
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshalling request body for %s: %w", requestPath, err)
+		}
+
+		reqBody = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestPath, reqBody)
+	if err != nil {
+		return fmt.Errorf("creating HTTP request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("performing HTTP request to %s: %w", requestPath, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d from %s", resp.StatusCode, requestPath)
+	}
+	if v != nil {
+		if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+			return fmt.Errorf("decoding response body from %s: %w", requestPath, err)
+		}
+	}
+
+	return nil
+}
+
 // getAPIVersionsForGR queries the API server for all supported versions of the specified GroupResource.
 // It returns a slice of version strings or an error if the query fails.
 func (c *Client) getAPIVersionsForGR(ctx context.Context, token, cluster string, groupResource schema.GroupResource) ([]string, error) {
@@ -501,6 +564,15 @@ func fetchCABundle() ([]byte, error) {
 		return nil, nil
 	}
 	return []byte(value), nil
+}
+
+func rootCAsFromBundle(bundle []byte) *x509.CertPool {
+	if len(bundle) == 0 {
+		return nil
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(bundle)
+	return pool
 }
 
 func rancherURLFromAuthServerURL(s string) (string, error) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,6 +2,9 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
@@ -460,6 +463,89 @@ func TestNewClient_RancherURL(t *testing.T) {
 			c, err := NewClient(true, test.authzServerURL)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedURL, c.RancherURL())
+		})
+	}
+}
+
+func TestGetRancherURL(t *testing.T) {
+	type collection struct {
+		Kind string `json:"kind"`
+		Data []any  `json:"data"`
+	}
+
+	tests := map[string]struct {
+		method         string
+		path           string
+		responseStatus int
+		responseBody   string
+		out            any
+		expectedOut    any
+		expectedErr    string
+	}{
+		"GET returns raw body on 200 with nil out": {
+			method:         http.MethodGet,
+			path:           "/v1/management.cattle.io.clusters",
+			responseStatus: http.StatusOK,
+			responseBody:   `{"kind":"Collection","data":[]}`,
+		},
+		"GET unmarshals into out when non-nil": {
+			method:         http.MethodGet,
+			path:           "/v1/management.cattle.io.clusters",
+			responseStatus: http.StatusOK,
+			responseBody:   `{"kind":"Collection","data":[]}`,
+			out:            &collection{},
+			expectedOut:    &collection{Kind: "Collection", Data: []any{}},
+		},
+		"DELETE returns body on 200": {
+			method:         http.MethodDelete,
+			path:           "/v1/management.cattle.io.clusters/c-m-12345",
+			responseStatus: http.StatusOK,
+			responseBody:   `{}`,
+		},
+		"returns error on 401": {
+			method:         http.MethodGet,
+			path:           "/v1/management.cattle.io.clusters",
+			responseStatus: http.StatusUnauthorized,
+			expectedErr:    "unexpected status 401",
+		},
+		"returns error on 500": {
+			method:         http.MethodGet,
+			path:           "/v1/management.cattle.io.clusters",
+			responseStatus: http.StatusInternalServerError,
+			expectedErr:    "unexpected status 500",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var receivedAuth string
+			var receivedMethod string
+			var receivedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedAuth = r.Header.Get("Authorization")
+				receivedMethod = r.Method
+				receivedPath = r.URL.Path
+				w.WriteHeader(test.responseStatus)
+				fmt.Fprint(w, test.responseBody)
+			}))
+			defer server.Close()
+
+			c := &Client{insecure: true, rancherURL: server.URL}
+
+			err := c.GetRancherURL(t.Context(), fakeToken, test.method, test.path, nil, test.out)
+
+			assert.Equal(t, test.method, receivedMethod)
+			assert.Equal(t, test.path, receivedPath)
+			assert.Equal(t, "Bearer "+fakeToken, receivedAuth)
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			if test.expectedOut != nil {
+				assert.Equal(t, test.expectedOut, test.out)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This adds support for getting arbitrary Rancher URLs so that we can get users and search for users.

For example:

```go
search := struct {
	Name          string  `json:"name"`
	PrincipalType *string `json:"principalType"`
}{
	Name:          "rancher",
	PrincipalType: new("group"),
}

type user struct {
	LoginName      string `json:"loginName,omitempty"`
	Name           string `json:"name"`
	ProfilePicture string `json:"profilePicture"`
	Type           string `json:"type"`
	ID             string `json:"id"`
	PrincipalType  string `json:"principalType"`
	Provider       string `json:"provider"`
}
result := new(struct {
	Data []user `json:"data"`
})

err = c.GetRancherURL(ctx, middleware.Token(ctx), http.MethodPost, "/v3/principals?action=search", &search, &result)
if err != nil {
	log.Fatal(err)
}
```