### PR TITLE
Add Namespace Move Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+__debug*
 
 # Test binary, built with `go test -c`
 *.test

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -54,6 +54,7 @@ Each tool is exposed through the MCP protocol and can be invoked by the Rancher 
 | `listProjectRoleTemplateBindings` | Read-only | List all project role template bindings (PRTBs) in a Rancher cluster.<br>If a user ID is specified only returns PRTBs for that user.<br>If a project ID is specified only returns PRTBs for that project.<br>PRTBs provide users permissions as specified by a RoleTemplate in a project. |
 | `listProjects` | Read-only | Returns a list of project resources for a specified cluster. |
 | `listRoleTemplates` | Read-only | List all role templates in a Rancher cluster.<br>Role templates define a set of permissions that can be assigned to users or groups. |
+| `moveNamespace` | Write | Moves a namespace to a project in the specified cluster. |
 | `patchKubernetesResource` | Write | Patches a Kubernetes resource using a JSON patch. Don't ask for confirmation. The namespace must be empty for cluster-wide resources. The content type used is application/json-patch+json. Returns the modified resource. |
 | `patchKubernetesResourcePlan` | Write | Plans to patch a Kubernetes resource using a JSON patch. It returns the JSON representation of the planned update without actually applying it in the cluster. Only used for displaying the patch when using human validation. The namespace must be empty for cluster-wide resources. The content type used is application/json-patch+json. |
 

--- a/pkg/toolsets/core/projects/move_namespace.go
+++ b/pkg/toolsets/core/projects/move_namespace.go
@@ -1,0 +1,80 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/rancher/rancher-ai-mcp/pkg/converter"
+	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type moveNamespaceParams struct {
+	Namespace string `json:"namespace" jsonschema:"the name of the namespace to move"`
+	Project   string `json:"project" jsonschema:"the name or ID of the destination project"`
+	Cluster   string `json:"cluster" jsonschema:"the name of the cluster containing the namespace and project"`
+}
+
+// moveNamespace assigns a namespace to a project.
+func (t *Tools) moveNamespace(ctx context.Context, toolReq *mcp.CallToolRequest, params moveNamespaceParams) (*mcp.CallToolResult, any, error) {
+	zap.L().Debug("moveNamespace called", zap.String("namespace", params.Namespace), zap.String("project", params.Project), zap.String("cluster", params.Cluster))
+
+	clusterID, err := t.client.GetClusterID(ctx, middleware.Token(ctx), params.Cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	projectID, _, err := t.getProjectID(ctx, middleware.Token(ctx), clusterID, params.Project)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	namespace, err := t.client.GetResource(ctx, client.GetParams{
+		Cluster: clusterID,
+		Kind:    "namespace",
+		Name:    params.Namespace,
+		Token:   middleware.Token(ctx),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get namespace %q: %w", params.Namespace, err)
+	}
+
+	labels := namespace.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["field.cattle.io/projectId"] = projectID
+	namespace.SetLabels(labels)
+
+	annotations := namespace.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["field.cattle.io/projectId"] = fmt.Sprintf("%s:%s", clusterID, projectID)
+	namespace.SetAnnotations(annotations)
+
+	resourceInterface, err := t.client.GetResourceInterface(
+		ctx, middleware.Token(ctx), "", clusterID, converter.K8sKindsToGVRs["namespace"])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	updatedNamespace, err := resourceInterface.Update(ctx, namespace, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to move namespace %q: %w", params.Namespace, err)
+	}
+
+	mcpResponse, err := response.CreateMcpResponse([]*unstructured.Unstructured{updatedNamespace}, clusterID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: mcpResponse}},
+	}, nil, nil
+}

--- a/pkg/toolsets/core/projects/move_namespace_test.go
+++ b/pkg/toolsets/core/projects/move_namespace_test.go
@@ -1,0 +1,103 @@
+package projects
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/internal/middleware"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestMoveNamespace(t *testing.T) {
+	const (
+		clusterID   = "c-move-namespace"
+		projectID   = "p-move-namespace"
+		projectName = "Destination Project"
+		namespace   = "workloads"
+		fakeToken   = "fakeToken"
+	)
+
+	cluster := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "Cluster",
+		"metadata":   map[string]any{"name": clusterID},
+	}}
+	project := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "Project",
+		"metadata":   map[string]any{"name": projectID, "namespace": clusterID},
+		"spec":       map[string]any{"displayName": projectName},
+	}}
+	namespaceResource := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+			Labels: map[string]string{
+				"field.cattle.io/projectId": "p-previous",
+				"team":                      "platform",
+			},
+			Annotations: map[string]string{
+				"field.cattle.io/projectId": "c-previous:p-previous",
+				"example.com/owner":         "platform",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, metav1.AddMetaToScheme(scheme))
+	fakeDynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		{Group: "management.cattle.io", Version: "v3", Resource: "clusters"}: "ClusterList",
+		{Group: "management.cattle.io", Version: "v3", Resource: "projects"}: "ProjectList",
+	}, cluster, project, namespaceResource)
+
+	c := &client.Client{DynClientCreator: func(*rest.Config) (dynamic.Interface, error) {
+		return fakeDynClient, nil
+	}}
+	tools := NewTools(newFakeToolsClient(c, fakeToken), false)
+
+	result, _, err := tools.moveNamespace(middleware.WithToken(t.Context(), fakeToken), &mcp.CallToolRequest{}, moveNamespaceParams{
+		Namespace: namespace,
+		Project:   projectName,
+		Cluster:   clusterID,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.JSONEq(t, `{
+		"llm": [{
+			"apiVersion": "v1",
+			"kind": "Namespace",
+			"metadata": {
+				"name": "workloads",
+				"labels": {
+					"field.cattle.io/projectId": "p-move-namespace",
+					"team": "platform"
+				},
+				"annotations": {
+					"field.cattle.io/projectId": "c-move-namespace:p-move-namespace",
+					"example.com/owner": "platform"
+				}
+			},
+			"spec": {},
+			"status": {}
+		}],
+		"uiContext": [{
+			"cluster": "c-move-namespace",
+			"kind": "Namespace",
+			"name": "workloads",
+			"namespace": "",
+			"type": "namespace"
+		}]
+	}`, result.Content[0].(*mcp.TextContent).Text)
+}

--- a/pkg/toolsets/core/projects/tools.go
+++ b/pkg/toolsets/core/projects/tools.go
@@ -84,5 +84,13 @@ The resource usage includes CPU and memory requests, limits and actual usage, as
 			},
 			Description: `Plans to create a project resource for a specified cluster. It returns the JSON representation of the project to be created without actually creating it in the cluster. Only used for displaying the resource when using human validation.`},
 			t.createProjectPlan)
+
+		mcp.AddTool(mcpServer, &mcp.Tool{
+			Name: "moveNamespace",
+			Meta: map[string]any{
+				toolsSetAnn: toolsSet,
+			},
+			Description: `Moves a namespace to a project in the specified cluster.`},
+			t.moveNamespace)
 	}
 }

--- a/pkg/toolsets/core/projects/tools_test.go
+++ b/pkg/toolsets/core/projects/tools_test.go
@@ -1,0 +1,77 @@
+package projects
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func startProjectsMCPServer(t *testing.T, tools *Tools) (*mcp.ClientSession, func()) {
+	t.Helper()
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "v1.0.0"}, nil)
+	tools.AddTools(mcpServer)
+
+	handler := mcp.NewStreamableHTTPHandler(func(request *http.Request) *mcp.Server { return mcpServer }, &mcp.StreamableHTTPOptions{})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &http.Server{Handler: handler}
+	go server.Serve(listener)
+
+	var session *mcp.ClientSession
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "mcp-client", Version: "v1.0.0"}, nil)
+	transport := &mcp.StreamableClientTransport{Endpoint: "http://" + listener.Addr().String()}
+	assert.Eventually(t, func() bool {
+		session, err = mcpClient.Connect(context.Background(), transport, nil)
+		return err == nil
+	}, 2*time.Second, 100*time.Millisecond)
+
+	require.NotNil(t, session)
+	return session, func() {
+		session.Close()
+		server.Shutdown(context.Background())
+		listener.Close()
+	}
+}
+
+func TestAddTools(t *testing.T) {
+	c, err := client.NewClient(true, "https://localhost:8080")
+	require.NoError(t, err)
+	session, cleanup := startProjectsMCPServer(t, NewTools(c, false))
+	defer cleanup()
+
+	toolsResult, err := session.ListTools(context.Background(), &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	assert.Len(t, toolsResult.Tools, 6, "incorrect number of project tools registered")
+
+	toolNames := make(map[string]bool)
+	for _, tool := range toolsResult.Tools {
+		toolNames[tool.Name] = true
+		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+	}
+	assert.True(t, toolNames["moveNamespace"])
+}
+
+func TestAddToolsReadOnly(t *testing.T) {
+	c, err := client.NewClient(true, "https://localhost:8080")
+	require.NoError(t, err)
+	session, cleanup := startProjectsMCPServer(t, NewTools(c, true))
+	defer cleanup()
+
+	toolsResult, err := session.ListTools(context.Background(), &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	assert.Len(t, toolsResult.Tools, 3, "incorrect number of read-only project tools registered")
+
+	for _, tool := range toolsResult.Tools {
+		assert.Equal(t, toolsSet, tool.Meta[toolsSetAnn])
+		assert.NotEqual(t, "moveNamespace", tool.Name)
+	}
+}

--- a/pkg/toolsets/core/tools_test.go
+++ b/pkg/toolsets/core/tools_test.go
@@ -63,7 +63,7 @@ func TestAddTools(t *testing.T) {
 	toolsResult, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
 
 	assert.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 21, "incorrect number of tools registered")
+	assert.Len(t, toolsResult.Tools, 22, "incorrect number of tools registered")
 	// assert that all tools have the correct toolset annotation
 	for _, tool := range toolsResult.Tools {
 		if tool.Name == "listClusters" {
@@ -138,4 +138,5 @@ func TestAddToolsReadOnly(t *testing.T) {
 	assert.False(t, toolNames["createKubernetesResourcePlan"], "createKubernetesResourcePlan should not be registered in read-only mode")
 	assert.False(t, toolNames["createProject"], "createProject should not be registered in read-only mode")
 	assert.False(t, toolNames["createProjectPlan"], "createProjectPlan should not be registered in read-only mode")
+	assert.False(t, toolNames["moveNamespace"], "moveNamespace should not be registered in read-only mode")
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher-ai-mcp/issues/62

Introduce a new MCP tool that moves a namespace from one project to another. It takes the cluster ID or name, project ID or name, and namespace name and then replaces the annotation and label necessary to move the namespace.

Tested with `gpt-oss-20b`. Some of the smarter models can do it without the tool, but gpt 20b fails without the tool.

> User: Move the namespace ns1 to projectB in the local cluster

> Liz: The namespace **ns1** has been successfully moved to **projectB** in the local cluster. The namespace’s project reference and associated annotations have been updated to reflect its new location. If you’d like to review any project‑specific settings such as quotas or resource limits, you can check the **Namespaces** → *ns1* → **Project** tab in the Rancher UI. Let me know if you need any further adjustments or if there’s anything else I can help with!

Repeating the same command doesn't cause issues since it just updates the labels to the same values.