### PR TITLE
Get the backing namespace of a project directly from the project object

### DIFF
--- a/pkg/toolsets/core/projects/common.go
+++ b/pkg/toolsets/core/projects/common.go
@@ -1,0 +1,70 @@
+package projects
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// getProjectID retrieves the project ID for a given project name or ID.
+func GetProjectID(ctx context.Context, tClient toolsClient, token, clusterID, projectNameOrID string) (string, *unstructured.Unstructured, error) {
+	// Check if the project was given by ID
+	projectResource, err := tClient.GetResource(ctx, client.GetParams{
+		Cluster:   LocalCluster,
+		Kind:      "project",
+		Namespace: clusterID,
+		Name:      projectNameOrID,
+		Token:     token,
+	})
+	if err == nil {
+		return projectResource.GetName(), projectResource, nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return "", nil, err
+	}
+
+	// Search for project by DisplayName
+	resources, err := tClient.GetResources(ctx, client.ListParams{
+		Cluster:   LocalCluster,
+		Kind:      "project",
+		Namespace: clusterID,
+		Token:     token,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	for _, resource := range resources {
+		displayName, found, err := unstructured.NestedString(resource.Object, "spec", "displayName")
+		if err != nil || !found {
+			continue
+		}
+
+		if strings.EqualFold(displayName, projectNameOrID) {
+			return resource.GetName(), resource, nil
+		}
+	}
+
+	return "", nil, fmt.Errorf("project '%s' not found in cluster '%s'", projectNameOrID, clusterID)
+}
+
+// Get the project backing namespace of a project. It is either <clusterID-projectID> or just <projectID>.
+// It is specified in the field "status.backingNamespace" but defaults to the name if that field isn't present.
+func GetProjectBackingNamespace(project *unstructured.Unstructured) (string, error) {
+	projectBackingNamespace, found, err := unstructured.NestedString(project.Object, "status", "backingNamespace")
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		projectBackingNamespace, found, err = unstructured.NestedString(project.Object, "metadata", "name")
+		if err != nil || !found {
+			return "", fmt.Errorf("failed to get backing namespace for project: %w", err)
+		}
+	}
+	return projectBackingNamespace, nil
+}

--- a/pkg/toolsets/core/projects/common_test.go
+++ b/pkg/toolsets/core/projects/common_test.go
@@ -1,0 +1,174 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rancher/rancher-ai-mcp/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+type commonTestClient struct {
+	getResource  func(client.GetParams) (*unstructured.Unstructured, error)
+	getResources func(client.ListParams) ([]*unstructured.Unstructured, error)
+}
+
+func (c *commonTestClient) GetClusterID(context.Context, string, string) (string, error) {
+	return "", nil
+}
+
+func (c *commonTestClient) GetResource(_ context.Context, params client.GetParams) (*unstructured.Unstructured, error) {
+	return c.getResource(params)
+}
+
+func (c *commonTestClient) GetResources(_ context.Context, params client.ListParams) ([]*unstructured.Unstructured, error) {
+	return c.getResources(params)
+}
+
+func (c *commonTestClient) GetResourceInterface(context.Context, string, string, string, schema.GroupVersionResource) (dynamic.ResourceInterface, error) {
+	return nil, nil
+}
+
+func project(name, displayName, backingNamespace string) *unstructured.Unstructured {
+	object := map[string]any{
+		"metadata": map[string]any{"name": name},
+	}
+	if displayName != "" {
+		object["spec"] = map[string]any{"displayName": displayName}
+	}
+	if backingNamespace != "" {
+		object["status"] = map[string]any{"backingNamespace": backingNamespace}
+	}
+	return &unstructured.Unstructured{Object: object}
+}
+
+func TestGetProjectID(t *testing.T) {
+	directProject := project("p-direct", "Direct Project", "")
+	matchedProject := project("p-matched", "Production", "")
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "management.cattle.io", Resource: "projects"}, "requested")
+
+	tests := map[string]struct {
+		projectName string
+		getResult   *unstructured.Unstructured
+		getErr      error
+		listResult  []*unstructured.Unstructured
+		listErr     error
+		wantID      string
+		wantErr     string
+		wantList    bool
+	}{
+		"returns project found by ID": {
+			projectName: "p-direct",
+			getResult:   directProject,
+			wantID:      "p-direct",
+		},
+		"finds project by case-insensitive display name": {
+			projectName: "production",
+			getErr:      notFound,
+			listResult:  []*unstructured.Unstructured{project("p-other", "Other", ""), matchedProject},
+			wantID:      "p-matched",
+			wantList:    true,
+		},
+		"returns not found after display name search": {
+			projectName: "missing",
+			getErr:      notFound,
+			listResult:  []*unstructured.Unstructured{matchedProject},
+			wantErr:     "project 'missing' not found in cluster 'c-123'",
+			wantList:    true,
+		},
+		"returns direct lookup error": {
+			projectName: "p-error",
+			getErr:      errors.New("access denied"),
+			wantErr:     "access denied",
+		},
+		"returns display name lookup error": {
+			projectName: "production",
+			getErr:      notFound,
+			listErr:     errors.New("list denied"),
+			wantErr:     "list denied",
+			wantList:    true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			listCalled := false
+			client := &commonTestClient{
+				getResource: func(params client.GetParams) (*unstructured.Unstructured, error) {
+					assert.Equal(t, client.GetParams{Cluster: LocalCluster, Kind: "project", Namespace: "c-123", Name: tt.projectName, Token: "token"}, params)
+					return tt.getResult, tt.getErr
+				},
+				getResources: func(params client.ListParams) ([]*unstructured.Unstructured, error) {
+					listCalled = true
+					assert.Equal(t, client.ListParams{Cluster: LocalCluster, Kind: "project", Namespace: "c-123", Token: "token"}, params)
+					return tt.listResult, tt.listErr
+				},
+			}
+
+			projectID, projectResource, err := GetProjectID(t.Context(), client, "token", "c-123", tt.projectName)
+
+			assert.Equal(t, tt.wantList, listCalled)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Empty(t, projectID)
+				assert.Nil(t, projectResource)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, projectID)
+			if tt.wantList {
+				assert.Same(t, matchedProject, projectResource)
+			} else {
+				assert.Same(t, directProject, projectResource)
+			}
+		})
+	}
+}
+
+func TestGetProjectBackingNamespace(t *testing.T) {
+	tests := map[string]struct {
+		project *unstructured.Unstructured
+		want    string
+		wantErr string
+	}{
+		"uses status backing namespace": {
+			project: project("p-abc", "", "local-p-abc"),
+			want:    "local-p-abc",
+		},
+		"falls back to project name": {
+			project: project("p-abc", "", ""),
+			want:    "p-abc",
+		},
+		"returns error for invalid backing namespace": {
+			project: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{"name": "p-abc"},
+				"status":   map[string]any{"backingNamespace": true},
+			}},
+			wantErr: ".status.backingNamespace accessor error",
+		},
+		"returns error when no backing namespace or name exists": {
+			project: &unstructured.Unstructured{Object: map[string]any{}},
+			wantErr: "failed to get backing namespace for project",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			backingNamespace, err := GetProjectBackingNamespace(tt.project)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Empty(t, backingNamespace)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, backingNamespace)
+		})
+	}
+}

--- a/pkg/toolsets/core/projects/get_project.go
+++ b/pkg/toolsets/core/projects/get_project.go
@@ -2,15 +2,12 @@ package projects
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/response"
 	"go.uber.org/zap"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -20,47 +17,6 @@ var zapGetProject = zap.String("tool", "getProject")
 type getProjectParams struct {
 	Name    string `json:"name" jsonschema:"the name of the project resource"`
 	Cluster string `json:"cluster" jsonschema:"the name of the cluster resource the project belongs to"`
-}
-
-// getProjectID retrieves the project ID for a given project name.
-func (t *Tools) getProjectID(ctx context.Context, token, clusterID, projectNameOrID string) (string, *unstructured.Unstructured, error) {
-	projectResource, err := t.client.GetResource(ctx, client.GetParams{
-		Cluster:   LocalCluster,
-		Kind:      "project",
-		Namespace: clusterID,
-		Name:      projectNameOrID,
-		Token:     token,
-	})
-	if err == nil {
-		return projectResource.GetName(), projectResource, nil
-	}
-
-	if !apierrors.IsNotFound(err) {
-		return "", nil, err
-	}
-
-	resources, err := t.client.GetResources(ctx, client.ListParams{
-		Cluster:   LocalCluster,
-		Kind:      "project",
-		Namespace: clusterID,
-		Token:     token,
-	})
-	if err != nil {
-		return "", nil, err
-	}
-
-	for _, resource := range resources {
-		displayName, found, err := unstructured.NestedString(resource.Object, "spec", "displayName")
-		if err != nil || !found {
-			continue
-		}
-
-		if strings.EqualFold(displayName, projectNameOrID) {
-			return resource.GetName(), resource, nil
-		}
-	}
-
-	return "", nil, fmt.Errorf("project '%s' not found in cluster '%s'", projectNameOrID, clusterID)
 }
 
 // getProject retrieves a project resource.
@@ -73,7 +29,7 @@ func (t *Tools) getProject(ctx context.Context, toolReq *mcp.CallToolRequest, pa
 		return nil, nil, err
 	}
 
-	projectID, projectResource, err := t.getProjectID(ctx, middleware.Token(ctx), clusterID, params.Name)
+	projectID, projectResource, err := GetProjectID(ctx, t.client, middleware.Token(ctx), clusterID, params.Name)
 	if err != nil {
 		zap.L().Error("failed to get project", zapGetProject, zap.Error(err))
 		return nil, nil, err

--- a/pkg/toolsets/core/projects/get_project_resource_usage.go
+++ b/pkg/toolsets/core/projects/get_project_resource_usage.go
@@ -84,7 +84,7 @@ func (t *Tools) getResourceUsage(ctx context.Context, toolReq *mcp.CallToolReque
 	} else {
 		var projectResources []*unstructured.Unstructured
 		if params.Project != "" {
-			_, projectResource, err := t.getProjectID(ctx, middleware.Token(ctx), clusterID, params.Project)
+			_, projectResource, err := GetProjectID(ctx, t.client, middleware.Token(ctx), clusterID, params.Project)
 			if err != nil {
 				zap.L().Error("failed to get project", zapGetResourceUsage, zap.Error(err))
 				return nil, nil, err

--- a/pkg/toolsets/core/rbac/list_projectroletemplatebindings.go
+++ b/pkg/toolsets/core/rbac/list_projectroletemplatebindings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher-ai-mcp/internal/middleware"
 	"github.com/rancher/rancher-ai-mcp/pkg/client"
 	"github.com/rancher/rancher-ai-mcp/pkg/response"
+	"github.com/rancher/rancher-ai-mcp/pkg/toolsets/core/projects"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -49,7 +50,16 @@ func (t *Tools) listProjectRoleTemplateBindings(ctx context.Context, toolReq *mc
 
 	namespace := ""
 	if params.ProjectID != "" {
-		projectBackingNamespace := clusterID + "-" + params.ProjectID
+		_, projectResource, err := projects.GetProjectID(ctx, t.client, middleware.Token(ctx), clusterID, params.ProjectID)
+		if err != nil {
+			zap.L().Error("failed to get project by ID", zapListProjectRoleTemplateBindings, zap.Error(err))
+			return nil, nil, err
+		}
+		projectBackingNamespace, err := projects.GetProjectBackingNamespace(projectResource)
+		if err != nil {
+			zap.L().Error("failed to get project backing namespace", zapListProjectRoleTemplateBindings, zap.Error(err))
+			return nil, nil, err
+		}
 		namespace = projectBackingNamespace
 	}
 

--- a/pkg/toolsets/core/rbac/list_projectroletemplatebindings_test.go
+++ b/pkg/toolsets/core/rbac/list_projectroletemplatebindings_test.go
@@ -56,6 +56,19 @@ func TestListProjectRoleTemplateBindings(t *testing.T) {
 			"roleTemplateName": "project-member",
 		},
 	}
+	projectABC := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "management.cattle.io/v3",
+			"kind":       "Project",
+			"metadata": map[string]any{
+				"name":      "p-abc",
+				"namespace": "local",
+			},
+			"status": map[string]any{
+				"backingNamespace": "local-p-abc",
+			},
+		},
+	}
 
 	tests := map[string]struct {
 		params         listPRTBParams
@@ -101,7 +114,7 @@ func TestListProjectRoleTemplateBindings(t *testing.T) {
 		},
 		"filter by project": {
 			params:  listPRTBParams{Cluster: "local", ProjectID: "p-abc"},
-			objects: []runtime.Object{prtb1, prtb2, prtb3},
+			objects: []runtime.Object{projectABC, prtb1, prtb2, prtb3},
 			expectedResult: `{
 				"llm": [
 					{
@@ -157,7 +170,7 @@ func TestListProjectRoleTemplateBindings(t *testing.T) {
 		},
 		"filter by project and user": {
 			params:  listPRTBParams{Cluster: "local", ProjectID: "p-abc", User: "u-user1"},
-			objects: []runtime.Object{prtb1, prtb2, prtb3},
+			objects: []runtime.Object{projectABC, prtb1, prtb2, prtb3},
 			expectedResult: `{
 				"llm": [
 					{

--- a/pkg/toolsets/core/rbac/tools_test.go
+++ b/pkg/toolsets/core/rbac/tools_test.go
@@ -24,6 +24,7 @@ const (
 
 var rbacGVRs = map[schema.GroupVersionResource]string{
 	{Group: "management.cattle.io", Version: "v3", Resource: "clusterroletemplatebindings"}: "ClusterRoleTemplateBindingList",
+	{Group: "management.cattle.io", Version: "v3", Resource: "projects"}:                    "ProjectList",
 	{Group: "management.cattle.io", Version: "v3", Resource: "projectroletemplatebindings"}: "ProjectRoleTemplateBindingList",
 	{Group: "management.cattle.io", Version: "v3", Resource: "roletemplates"}:               "RoleTemplateList",
 	{Group: "management.cattle.io", Version: "v3", Resource: "users"}:                       "UserList",


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher-ai-agent/issues/54#issuecomment-5176118904

ProjectRoleTemplateBindings are created in a project's backing namespace. Most of the time this is in the format `clusterID-projectID`. But sometimes, it can just be `projectID` if the webhook responsible for generating the project backing namespace isn't running yet. This really only happens for `Default` and `System` projects and for any that have existed since before the fix in v2.8.

Prior to this change, we were building the backing namespace name assuming it was `clusterID-projectID`. Instead we can actually get the backing namespace directly from the project object. I've created a function that does exactly that and fixed `listProjectRoleTemplateBindings` to use that helper function.